### PR TITLE
[🔨chore]: figma 상의 gap 속성을 tailwind 상 spacing으로 변경

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -75,7 +75,7 @@ export default {
         lg: "24px", // radius/lg
         circle: "99999px", // radius/circle
       },
-      gap: {
+      spacing: {
         none: "0px", // gap/none
         "7xs": "1px", // gap/7xs
         "6xs": "2px", // gap/6xs


### PR DESCRIPTION
- `tailwind.config` 파일의 gap에만 저장해두면, `gap-2xl`에서만 사용할 수 있고, `padding`이나 `margin` 등 다양한 간격에서는 사용할 수 없음
- 디자인 시스템 상의 `Gap`은 `CSS` 상의 `gap`만 의미하는 것이 아니라, 일반적인 "간격"을 의미함
- 따라서, `spacing`에 저장해두어 `gap`, `padding`, `margin`에서 모두 해당 디자인 시스템을 사용할 수 있도록 함

[사용 예시]
- `figma` 상 item spacing : gap/4sx => tailwind 상 `gap-4xs`
- `figma` 상 padding : gap/4xs => tailwind 상 `p-4xs`