### PR TITLE
[🔨chore]: storybook에서 svgr 사용 가능하도록 설정

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,5 +11,25 @@ const config: StorybookConfig = {
     name: "@storybook/nextjs",
     options: {},
   },
+  webpackFinal: async (config) => {
+    const imageRule = config.module?.rules?.find((rule) => {
+      const test = (rule as { test: RegExp }).test;
+
+      if (!test) {
+        return false;
+      }
+
+      return test.test(".svg");
+    }) as { [key: string]: any };
+
+    imageRule.exclude = /\.svg$/;
+
+    config.module?.rules?.push({
+      test: /\.svg$/,
+      use: ["@svgr/webpack"],
+    });
+
+    return config;
+  },
 };
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,9 +15,7 @@ const config: StorybookConfig = {
     const imageRule = config.module?.rules?.find((rule) => {
       const test = (rule as { test: RegExp }).test;
 
-      if (!test) {
-        return false;
-      }
+      if (!test) return false;
 
       return test.test(".svg");
     }) as { [key: string]: any };


### PR DESCRIPTION
## 🚀 작업 내용

- [x] `storybook`에서 `svgr`을 통한 `svg` 사용이 가능하도록 설정했습니다.

## ✨ 작업 상세 설명

`Next Image` 는 `svg`를 사용할 수가 없어서 `svgr` 라이브러리를 통해 `svg` 이미지를 불러오도록 했다. 
하지만 `storybook` 에서는 해당 `svg`를 읽을 수 없다는 오류가 발생

### 🔥 문제 상황 

Next local에서는 아이콘이 잘 보임
![image](https://github.com/user-attachments/assets/3c2aeec0-a25a-4a15-a3c1-02a42c365d3a)

storybook에서의 오류
![image](https://github.com/user-attachments/assets/201bfe50-7a40-4fa3-9fe2-15534f605c19)

### 💦 해결 방법

`.storybook/main.ts` 파일에 config를 추가해줬다.

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE

- https://velog.io/@ckstn0777/nextjs13-storybook-svgr
- https://github.com/storybookjs/storybook/issues/18557#issuecomment-1426150038

## 📢 리뷰 요구 사항 (선택)
