### PR TITLE
[✨feat]: IndexPanel 컴포넌트 구현

### DIFF
--- a/src/components/IndexPanel/IndexPanel.style.ts
+++ b/src/components/IndexPanel/IndexPanel.style.ts
@@ -27,9 +27,6 @@ export const IndexPanelItem = styled.div<IIndexPanelItemStyle>`
   ${(props) =>
     props.$isSelected &&
     `background-color: ${props.theme.light["object-hero"]}`};
-`;
-
-export const IndexPanelItemLabelText = styled.span<IIndexPanelItemStyle>`
   color: ${(props) =>
     props.$isSelected
       ? props.theme.light["object-hero"]

--- a/src/components/IndexPanel/IndexPanel.style.ts
+++ b/src/components/IndexPanel/IndexPanel.style.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import styled from "styled-components";
+import DESIGN_SYSTEM from "@/styles/designSystem";
+
+/**
+ * IndexPanel/Item 컴포넌트에 필요한 style props입니다
+ */
+export interface IIndexPanelItemStyle {
+  $isSelected?: boolean;
+  $isDisabled?: boolean;
+}
+
+export const IndexPanelItem = styled.div<IIndexPanelItemStyle>`
+  position: relative;
+
+  display: inline-flex;
+  padding: ${DESIGN_SYSTEM.gap["6xs"]} ${DESIGN_SYSTEM.gap["4xs"]};
+  align-items: center;
+  gap: ${DESIGN_SYSTEM.gap["4xs"]};
+
+  width: 100%;
+  height: fit-content;
+
+  border-radius: ${DESIGN_SYSTEM.radius["2xs"]};
+
+  ${(props) =>
+    props.$isSelected &&
+    `background-color: ${props.theme.light["object-hero"]}`};
+`;
+
+export const IndexPanelItemLabelText = styled.span<IIndexPanelItemStyle>`
+  color: ${(props) =>
+    props.$isSelected
+      ? props.theme.light["object-hero"]
+      : props.theme.light["object-subtle"]};
+
+  &:hover,
+  &:focus-visible {
+    color: ${({ theme }) => theme.light["object-hero"]};
+  }
+
+  ${(props) =>
+    props.$isDisabled && `color: ${props.theme.light["object-subtlest"]};`}
+
+  ${DESIGN_SYSTEM.typography.label.xs}
+`;
+
+export const IndexPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${DESIGN_SYSTEM.gap.xs};
+  padding: ${DESIGN_SYSTEM.gap.xs} ${DESIGN_SYSTEM.gap["2xs"]};
+
+  width: 12.5rem;
+
+  border-radius: ${DESIGN_SYSTEM.radius.sm};
+  border: ${DESIGN_SYSTEM.stroke.normal} solid
+    ${({ theme }) => theme.light["border-trans-subtler"]};
+
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+  background: ${({ theme }) => theme.light["surface-standard"]};
+
+  box-shadow: ${DESIGN_SYSTEM.shadow.embossed};
+`;
+
+export const IndexPanelItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.sm};
+  padding: ${DESIGN_SYSTEM.gap.none} ${DESIGN_SYSTEM.gap["5xs"]};
+`;

--- a/src/components/IndexPanel/IndexPanel.tsx
+++ b/src/components/IndexPanel/IndexPanel.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import InteractionContainer from "../Interaction/Interaction.style";
+import * as S from "./IndexPanel.style";
+
+/**
+ * IndexPanel/Item 컴포넌트에 필요한 props입니다
+ */
+interface IIndexPanelItem extends S.IIndexPanelItemStyle {
+  text: string;
+  contentRef: React.RefObject<HTMLElement>;
+}
+
+/**
+ * IndexPanel/Item 컴포넌트 입니다. IndexPanel에서만 사용됩니다.
+ */
+function IndexPanelItem({
+  $isSelected = false,
+  $isDisabled = false,
+  text,
+  contentRef,
+}: IIndexPanelItem) {
+  // TODO: 목차 중 해당 위치에 닿으면 isSelected true되도록 구현하기
+  const [isSelected, setIsSelected] = useState($isSelected);
+
+  const onContentClick = () => {
+    contentRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <S.IndexPanelItem $isSelected={isSelected} $isDisabled={$isDisabled}>
+      <S.IndexPanelItemLabelText
+        $isSelected={$isSelected}
+        $isDisabled={$isDisabled}
+        onClick={onContentClick}
+      >
+        {text || ""}
+      </S.IndexPanelItemLabelText>
+      <InteractionContainer $variant="default" $density="subtle" />
+    </S.IndexPanelItem>
+  );
+}
+
+/**
+ * IndexPanel 컴포넌트에 필요한 props입니다.
+ */
+interface IIndexPanel {
+  bannerRef: React.RefObject<HTMLElement>;
+  explanationRef: React.RefObject<HTMLElement>;
+  exampleRef: React.RefObject<HTMLElement>;
+  referenceRef: React.RefObject<HTMLElement>;
+  commentsRef: React.RefObject<HTMLElement>;
+}
+
+/**
+ * IndexPanel 컴포넌트입니다
+ */
+function IndexPanel({
+  bannerRef,
+  explanationRef,
+  exampleRef,
+  referenceRef,
+  commentsRef,
+}: IIndexPanel) {
+  return (
+    <S.IndexPanel>
+      <S.IndexPanelItemContainer>
+        <IndexPanelItem text="배너" contentRef={bannerRef} />
+        <IndexPanelItem text="설명" contentRef={explanationRef} />
+        <IndexPanelItem text="간단 용례" contentRef={exampleRef} />
+        <IndexPanelItem text="참고자료 및 문헌" contentRef={referenceRef} />
+        <IndexPanelItem text="댓글" contentRef={commentsRef} />
+      </S.IndexPanelItemContainer>
+    </S.IndexPanel>
+  );
+}
+
+export default IndexPanel;

--- a/src/components/IndexPanel/IndexPanel.tsx
+++ b/src/components/IndexPanel/IndexPanel.tsx
@@ -32,7 +32,7 @@ function IndexPanelItem({
       $isDisabled={$isDisabled}
       onClick={onContentClick}
     >
-      {text || ""}
+      {text}
       <InteractionContainer $variant="default" $density="subtle" />
     </S.IndexPanelItem>
   );

--- a/src/components/IndexPanel/IndexPanel.tsx
+++ b/src/components/IndexPanel/IndexPanel.tsx
@@ -27,14 +27,12 @@ function IndexPanelItem({
   };
 
   return (
-    <S.IndexPanelItem $isSelected={isSelected} $isDisabled={$isDisabled}>
-      <S.IndexPanelItemLabelText
-        $isSelected={$isSelected}
-        $isDisabled={$isDisabled}
-        onClick={onContentClick}
-      >
-        {text || ""}
-      </S.IndexPanelItemLabelText>
+    <S.IndexPanelItem
+      $isSelected={isSelected}
+      $isDisabled={$isDisabled}
+      onClick={onContentClick}
+    >
+      {text || ""}
       <InteractionContainer $variant="default" $density="subtle" />
     </S.IndexPanelItem>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as BadgeComponentType } from "./Badge/Badge.ComponentType";
 export { default as Toast } from "./Toast/Toast";
 export { default as Callout } from "./Callout/Callout";
 export { default as CalloutInteractive } from "./Callout/Callout.Interactive";
+export { default as IndexPanel } from "./IndexPanel/IndexPanel";

--- a/src/stories/IndexPanel.stories.tsx
+++ b/src/stories/IndexPanel.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { IndexPanel } from "../components";
+
+const meta = {
+  component: IndexPanel,
+  title: "Components/IndexPanel",
+  tags: ["autodocs"],
+  excludeStories: /.*Data$/,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof IndexPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    bannerRef: { current: null } as React.RefObject<HTMLDivElement>,
+    explanationRef: { current: null } as React.RefObject<HTMLDivElement>,
+    exampleRef: { current: null } as React.RefObject<HTMLDivElement>,
+    referenceRef: { current: null } as React.RefObject<HTMLDivElement>,
+    commentsRef: { current: null } as React.RefObject<HTMLDivElement>,
+  },
+};


### PR DESCRIPTION
## 🚀 작업 내용

- [x] IndexPanel 컴포넌트를 구현했습니다.

## ✨ 작업 상세 설명

> 목차 패널은 어디서 사용되든지 `Item`을 동일하게 가져갈 것으로 예상되어, 그대로 구현했습니다. (`IndexPanel/Item`을 통한 커스터마이징 불가)

![image](https://github.com/user-attachments/assets/a2d02d5c-dbe0-4663-87c4-8b901a10aade)

사용할 때 배너, 설명, 간단 용례, 참고자료 및 문헌, 댓글에 대한 `ref`를 설정해서 `props`로 전달해줘야 한다.

### 🔥 문제 상황 1 - storybook과 local에서 보이는게 다르다.
- 좌측 storybook, 우측 local
<img width="240" alt="image" src="https://github.com/user-attachments/assets/8d59cf4e-05e5-44a6-9354-8e57f0714c59" /> <img width="204" alt="image" src="https://github.com/user-attachments/assets/9e209cbd-e5bc-4cf4-8b7d-ecd5f7298ce9" />
- 좌측에서는 `Item`의 `width`가 더 길어 보인다. 하지만, `local`에서는 정상적으로 보이는 모습을 확인할 수 있다.

### 💦 해결 방법 

- 해결 해야하는가?? 🤔 급하거나 중요한건 아닌 것 같아서 해결하지 않았다.

### 🔥 문제 상황 2 - hover시에 글자 색이 안바뀐다.

- `IndexPanelItemLabelText` 컴포넌트보다 `interaction` 컴포넌트가 상위에 덮여있기 때문에, `IndexPanelItemLabelText` 를 감싸는 `span` 태그에는 `hover`가 정상 동작하지 않는다. (오른쪽은 정상 동작시 모습임)
<img width="204" alt="image" src="https://github.com/user-attachments/assets/9e209cbd-e5bc-4cf4-8b7d-ecd5f7298ce9" /> <img width="203" alt="image" src="https://github.com/user-attachments/assets/2ffaa89c-e76d-4d5b-a334-8c2df4c3cdf6" /> 

### 💦 해결 방법 
- `IndexPanelItem`와 `IndexPanelItemLabelText`로 나뉘어져있던걸 하나로 합쳤습니다! (어차피 layout 설정은 없고 color 설정만 있었기에 가능했음)
- 이제 잘 작동합니다~

## 🔨 추후 수정해야 하는 부분 (선택)

- [ ] 현재 사용자가 해당 `ref`의 컨텐츠를 보고 있다면 `isSelected`를 `true`로 바꿔주는 로직을 구현해야 합니다. (예를 들어 사용자가 "간단 용례" 부분을 보고 있다면 "간단 용례(`explanationRef`)"를 가진 `Item` 컴포넌트의 `isSelected`는 `true`가 되고, 그 외의 `Item` 컴포넌트의 `isSelected`는 `false`로 설정합니다.)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
~~- `Interaction` 컴포넌트를 어떻게 수정해야 좋을지 혹시 아이디어가 있으시다면 환영입니다 ㅠㅠ~~