### PR TITLE
[✨feat]: button component 구현

### DIFF
--- a/src/components/Button/Button.style.tsx
+++ b/src/components/Button/Button.style.tsx
@@ -1,0 +1,103 @@
+import styled, { css } from "styled-components";
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import { BUTTON_SIZE_MAP, BUTTON_STYLES } from "./Button.theme";
+import { IButtonComponent, IIconWrapper } from "./Button.types";
+
+function IconWrapper({ IconComponent, ...props }: IIconWrapper) {
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <IconComponent {...props} />;
+}
+
+export const Button = styled.button<IButtonComponent>`
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  position: relative;
+  padding: ${(props) =>
+    props.$buttonType === "button"
+      ? BUTTON_SIZE_MAP[props.$size].padding
+      : BUTTON_SIZE_MAP[props.$size].icBtnPadding};
+
+  border: ${DESIGN_SYSTEM.stroke.none};
+  border-radius: ${DESIGN_SYSTEM.radius.xs};
+
+  ${({ $buttonStyle, theme }) => {
+    if (!$buttonStyle) return BUTTON_STYLES.solidBrand(theme);
+    return BUTTON_STYLES[$buttonStyle](theme);
+  }}
+`;
+
+export const LabelContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  gap: ${DESIGN_SYSTEM.gap["4xs"]};
+`;
+
+const BaseIconImg = styled(IconWrapper)<IButtonComponent>`
+  width: ${(props) =>
+    props.$buttonType === "button"
+      ? BUTTON_SIZE_MAP[props.$size].icon
+      : BUTTON_SIZE_MAP[props.$size].icBtnIcon};
+  height: ${(props) =>
+    props.$buttonType === "button"
+      ? BUTTON_SIZE_MAP[props.$size].icon
+      : BUTTON_SIZE_MAP[props.$size].icBtnIcon};
+
+  path {
+    ${({ $buttonStyle, theme }) => {
+      switch ($buttonStyle) {
+        case "solidPrimary":
+          return css`
+            fill: ${theme.light["object-inv-hero"]};
+          `;
+        case "solidSecondary":
+          return css`
+            fill: ${theme.light["object-static-inv-hero"]};
+          `;
+        case "solidTertiary":
+          return css`
+            fill: ${theme.light["object-bold"]};
+          `;
+        case "outlinedPrimary":
+          return css`
+            fill: ${theme.light["object-hero"]};
+          `;
+        case "outlinedSecondary":
+          return css`
+            fill: ${theme.light["object-normal"]};
+          `;
+        case "outlinedTertiary":
+          return css`
+            fill: ${theme.light["object-subtle"]};
+          `;
+        case "emptyPrimary":
+          return css`
+            fill: ${theme.light["object-hero"]};
+          `;
+        case "emptySecondary":
+          return css`
+            fill: ${theme.light["object-normal"]};
+          `;
+        case "emptyTertiary":
+          return css`
+            fill: ${theme.light["object-subtle"]};
+          `;
+        default:
+          return null;
+      }
+    }}
+  }
+`;
+
+export const LeftIconImg = styled(BaseIconImg)``;
+
+export const LabelText = styled.span<IButtonComponent>`
+  text-align: center;
+  ${(props) => BUTTON_SIZE_MAP[props.$size].typo};
+`;
+
+export const RightIconImg = styled(BaseIconImg)``;

--- a/src/components/Button/Button.theme.ts
+++ b/src/components/Button/Button.theme.ts
@@ -1,0 +1,76 @@
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import { DefaultTheme, css } from "styled-components";
+
+export const BUTTON_SIZE_MAP = {
+  lg: {
+    icon: DESIGN_SYSTEM.iconSize.md,
+    typo: DESIGN_SYSTEM.typography.label.lg,
+    padding: `${DESIGN_SYSTEM.gap.xs} ${DESIGN_SYSTEM.gap.md}`,
+    icBtnPadding: DESIGN_SYSTEM.gap.xs,
+    icBtnIcon: DESIGN_SYSTEM.iconSize["2xl"],
+  },
+  md: {
+    icon: DESIGN_SYSTEM.iconSize.sm,
+    typo: DESIGN_SYSTEM.typography.label.md,
+    padding: `${DESIGN_SYSTEM.gap["2xs"]} ${DESIGN_SYSTEM.gap.sm}`,
+    icBtnPadding: DESIGN_SYSTEM.gap["3xs"],
+    icBtnIcon: DESIGN_SYSTEM.iconSize.lg,
+  },
+  sm: {
+    icon: DESIGN_SYSTEM.iconSize.xs,
+    typo: DESIGN_SYSTEM.typography.label.sm,
+    padding: `${DESIGN_SYSTEM.gap["3xs"]} ${DESIGN_SYSTEM.gap.xs}`,
+    icBtnPadding: DESIGN_SYSTEM.gap["4xs"],
+    icBtnIcon: DESIGN_SYSTEM.iconSize.sm,
+  },
+  xs: {
+    icon: DESIGN_SYSTEM.iconSize["2xs"],
+    typo: DESIGN_SYSTEM.typography.label.xs,
+    padding: `${DESIGN_SYSTEM.gap["4xs"]} ${DESIGN_SYSTEM.gap["2xs"]}`,
+    icBtnPadding: DESIGN_SYSTEM.gap["5xs"],
+    icBtnIcon: DESIGN_SYSTEM.iconSize["2xs"],
+  },
+};
+
+export const BUTTON_STYLES = {
+  solidBrand: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-static-boldest"]};
+    background-color: ${theme.light["accent-bold"]};
+  `,
+  solidPrimary: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-inv-hero"]};
+    background-color: ${theme.light["object-hero"]};
+  `,
+  solidSecondary: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-static-inv-hero"]};
+    background-color: ${theme.light["fill-trans-bolder"]};
+  `,
+  solidTertiary: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-bold"]};
+    background-color: ${theme.light["fill-trans-subtler"]};
+  `,
+  outlinedPrimary: (theme: DefaultTheme) => css`
+    border: ${DESIGN_SYSTEM.stroke.normal} solid
+      ${theme.light["border-trans-normal"]};
+    color: ${theme.light["object-hero"]};
+  `,
+  outlinedSecondary: (theme: DefaultTheme) => css`
+    border: ${DESIGN_SYSTEM.stroke.normal} solid
+      ${theme.light["border-trans-subtle"]};
+    color: ${theme.light["object-normal"]};
+  `,
+  outlinedTertiary: (theme: DefaultTheme) => css`
+    border: ${DESIGN_SYSTEM.stroke.normal} solid
+      ${theme.light["border-trans-subtle"]};
+    color: ${theme.light["object-subtle"]};
+  `,
+  emptyPrimary: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-hero"]};
+  `,
+  emptySecondary: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-normal"]};
+  `,
+  emptyTertiary: (theme: DefaultTheme) => css`
+    color: ${theme.light["object-subtle"]};
+  `,
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,65 @@
+import InteractionContainer from "../Interaction/Interaction.style";
+import { IButton, ButtonStyle } from "./Button.types";
+import * as S from "./Button.style";
+import { BUTTON_SIZE_MAP } from "./Button.theme";
+
+function renderIcon(
+  IconComponent: React.ElementType | undefined,
+  $buttonType: "button" | "iconButton",
+  $buttonStyle: ButtonStyle,
+  $size: keyof typeof BUTTON_SIZE_MAP,
+  isVisible: boolean,
+) {
+  if (!isVisible || !IconComponent) return null;
+
+  return (
+    <S.LeftIconImg
+      $buttonType={$buttonType}
+      $buttonStyle={$buttonStyle}
+      $size={$size}
+      IconComponent={IconComponent}
+    />
+  );
+}
+
+export default function Button({
+  text,
+  $leftIcon,
+  $rightIcon,
+  $size,
+  $buttonStyle,
+  $buttonType = "button",
+  $isLeftIconVisible = true,
+  $isRightIconVisible = true,
+}: IButton) {
+  return (
+    <S.Button $buttonStyle={$buttonStyle} $size={$size}>
+      <S.LabelContainer>
+        {$buttonType === "iconButton" &&
+          renderIcon($leftIcon, $buttonType, $buttonStyle, $size, true)}
+        {$buttonType === "button" && (
+          <>
+            {renderIcon(
+              $leftIcon,
+              $buttonType,
+              $buttonStyle,
+              $size,
+              $isLeftIconVisible,
+            )}
+            <S.LabelText $buttonStyle={$buttonStyle} $size={$size}>
+              {text}
+            </S.LabelText>
+            {renderIcon(
+              $rightIcon,
+              $buttonType,
+              $buttonStyle,
+              $size,
+              $isRightIconVisible,
+            )}
+          </>
+        )}
+      </S.LabelContainer>
+      <InteractionContainer $variant="default" $density="normal" tabIndex={0} />
+    </S.Button>
+  );
+}

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -1,0 +1,32 @@
+import { BUTTON_SIZE_MAP } from "./Button.theme";
+
+export interface IIconWrapper {
+  IconComponent: React.ElementType;
+}
+
+export enum ButtonStyle {
+  SolidBrand = "solidBrand",
+  SolidPrimary = "solidPrimary",
+  SolidSecondary = "solidSecondary",
+  SolidTertiary = "solidTertiary",
+  OutlinedPrimary = "outlinedPrimary",
+  OutlinedSecondary = "outlinedSecondary",
+  OutlinedTertiary = "outlinedTertiary",
+  EmptyPrimary = "emptyPrimary",
+  EmptySecondary = "emptySecondary",
+  EmptyTertiary = "emptyTertiary",
+}
+
+export interface IButtonComponent {
+  $size: keyof typeof BUTTON_SIZE_MAP;
+  $buttonStyle: ButtonStyle;
+  $buttonType?: "button" | "iconButton";
+}
+
+export interface IButton extends IButtonComponent {
+  text?: string;
+  $leftIcon?: React.ElementType;
+  $rightIcon?: React.ElementType;
+  $isLeftIconVisible: boolean;
+  $isRightIconVisible: boolean;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as Callout } from "./Callout/Callout";
 export { default as Chip } from "./Chip/Chip";
 export { default as ChipGroup } from "./Chip/Chip.group";
 export { default as CalloutInteractive } from "./Callout/Callout.Interactive";
+export { default as Button } from "./Button/Button";

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@/components";
+import BlankLine from "@/assets/icons/blank-line.svg";
+import { ButtonStyle } from "@/components/Button/Button.types";
+
+const meta = {
+  title: "Components/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    text: {
+      control: { type: "text" },
+      defaultValue: "버튼",
+    },
+    $leftIcon: {
+      defaultValue: BlankLine,
+    },
+    $rightIcon: {
+      defaultValue: BlankLine,
+    },
+    $size: {
+      control: { type: "select" },
+      options: ["lg", "md", "sm", "xs"],
+      defaultValue: "md",
+    },
+    $buttonStyle: {
+      control: { type: "select" },
+      options: [
+        ButtonStyle.SolidBrand,
+        ButtonStyle.SolidPrimary,
+        ButtonStyle.SolidSecondary,
+        ButtonStyle.SolidTertiary,
+        ButtonStyle.OutlinedPrimary,
+        ButtonStyle.OutlinedSecondary,
+        ButtonStyle.OutlinedTertiary,
+        ButtonStyle.EmptyPrimary,
+        ButtonStyle.EmptySecondary,
+        ButtonStyle.EmptyTertiary,
+      ],
+      defaultValue: ButtonStyle.SolidPrimary,
+    },
+    $buttonType: {
+      control: { type: "select" },
+      options: ["button", "iconButton"],
+      defaultValue: "button",
+    },
+    $isLeftIconVisible: {
+      control: { type: "boolean" },
+      defaultValue: true,
+    },
+    $isRightIconVisible: {
+      control: { type: "boolean" },
+      defaultValue: true,
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    text: "버튼",
+    $size: "md",
+    $buttonStyle: ButtonStyle.SolidPrimary,
+    $buttonType: "button",
+    $leftIcon: BlankLine,
+    $rightIcon: BlankLine,
+    $isLeftIconVisible: true,
+    $isRightIconVisible: true,
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    ...Default.args,
+    $leftIcon: BlankLine,
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    ...Default.args,
+    $rightIcon: BlankLine,
+  },
+};
+
+export const IconButton: Story = {
+  args: {
+    $size: "lg",
+    $buttonStyle: ButtonStyle.SolidPrimary,
+    $buttonType: "iconButton",
+    $leftIcon: BlankLine,
+    $isLeftIconVisible: true,
+    $isRightIconVisible: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    $isLeftIconVisible: false,
+    $isRightIconVisible: false,
+  },
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   argTypes: {
     text: {
       control: { type: "text" },
-      defaultValue: "버튼",
+      defaultValue: "레이블",
     },
     $leftIcon: {
       defaultValue: BlankLine,
@@ -40,7 +40,7 @@ const meta = {
         ButtonStyle.EmptySecondary,
         ButtonStyle.EmptyTertiary,
       ],
-      defaultValue: ButtonStyle.SolidPrimary,
+      defaultValue: ButtonStyle.SolidBrand,
     },
     $buttonType: {
       control: { type: "select" },
@@ -64,9 +64,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    text: "버튼",
+    text: "레이블",
     $size: "md",
-    $buttonStyle: ButtonStyle.SolidPrimary,
+    $buttonStyle: ButtonStyle.SolidBrand,
     $buttonType: "button",
     $leftIcon: BlankLine,
     $rightIcon: BlankLine,
@@ -75,35 +75,100 @@ export const Default: Story = {
   },
 };
 
-export const WithLeftIcon: Story = {
+export const ButtonSolidPrimary: Story = {
   args: {
     ...Default.args,
+    $buttonStyle: ButtonStyle.SolidPrimary,
+  },
+};
+
+export const ButtonSolidSecondary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.SolidSecondary,
+  },
+};
+
+export const ButtonSolidTertiary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.SolidTertiary,
+  },
+};
+
+export const ButtonOutlinedPrimary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.OutlinedPrimary,
+  },
+};
+
+export const ButtonOutlinedSecondary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.OutlinedSecondary,
+  },
+};
+
+export const ButtonOutlinedTertiary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.OutlinedTertiary,
+  },
+};
+
+export const ButtonEmptyPrimary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.EmptyPrimary,
+  },
+};
+
+export const ButtonEmptySecondary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.EmptySecondary,
+  },
+};
+
+export const ButtonEmptyTertiary: Story = {
+  args: {
+    ...Default.args,
+    $buttonStyle: ButtonStyle.EmptyTertiary,
+  },
+};
+
+export const isLeftIconVisible: Story = {
+  args: {
+    ...Default.args,
+    $isRightIconVisible: false,
     $leftIcon: BlankLine,
   },
 };
 
-export const WithRightIcon: Story = {
+export const isRightIconVisible: Story = {
   args: {
     ...Default.args,
+    $isLeftIconVisible: false,
     $rightIcon: BlankLine,
   },
 };
 
-export const IconButton: Story = {
+export const isIconInvisible: Story = {
   args: {
-    $size: "lg",
-    $buttonStyle: ButtonStyle.SolidPrimary,
-    $buttonType: "iconButton",
-    $leftIcon: BlankLine,
-    $isLeftIconVisible: true,
+    ...Default.args,
+    $isLeftIconVisible: false,
     $isRightIconVisible: false,
   },
 };
 
-export const Disabled: Story = {
+export const IcBtn: Story = {
   args: {
-    ...Default.args,
-    $isLeftIconVisible: false,
+    $size: "md",
+    $buttonStyle: ButtonStyle.SolidBrand,
+    $buttonType: "iconButton",
+    $leftIcon: BlankLine,
+    $isLeftIconVisible: true,
     $isRightIconVisible: false,
   },
 };


### PR DESCRIPTION
## 🚀 작업 내용

- [x] button component 구현 

## ✨ 작업 상세 설명

> figma [button 디자인 시스템](https://www.figma.com/design/DYKX0B40H5ZVViUtva7HPa/%F0%9F%92%A0%EC%BB%B4%ED%8F%AC%EB%85%B8%ED%8A%B8-%EB%94%94%EC%9E%90%EC%9D%B8-%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=228-59754&p=f&m=dev)을 기반으로 button component 구현을 진행했습니다. 스토리북에서 확인 가능합니다. :>

![스크린샷 2024-12-28 오후 5 18 04](https://github.com/user-attachments/assets/bb0a67ce-c0ff-4919-920a-95bdf1ca42a4)

### 🔥 문제 상황 (선택)

> 인터랙션 컴포넌트가 `ComponentContainer` 하단에 위치하다 보니 `tabIndex`를 사용해 확인했을 때 `ComponentContainer` (e.g. button component라면 `button`의 최상위 부모 DOM)가 먼저 잡히고, 하위의 `InteractionComponent` 포커스가 잡힙니다.

그래서 포커스가 같은 컴포넌트에 두 번 번갈아서 나타난다는 문제 상황이 발생하고 있어요.
→ `ComponentContainer`에 적용된 기본 focus 스타일, `InteractionComponent`에 적용된 focus 스타일

### 💦 해결 방법 (선택)

해결 방법은 찾는 중입니다! 🥹

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
