### PR TITLE
[✨feat]: ContextMenu 컴포넌트 구현

### DIFF
--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -29,6 +29,14 @@ export interface IStyle {
   outlined: IColor & { border: string };
 }
 
+export enum BadgeLabelFeedback {
+  NONE = "none",
+  NEGATIVE = "negative",
+  INFO = "info",
+  POSITIVE = "positive",
+  NOTIFICATION = "notification",
+}
+
 export interface IBadgeLabelFeedbackColor {
   none: IStyle;
   negative: IStyle;
@@ -41,7 +49,7 @@ export interface IBadgeLabelFeedbackColor {
  * Badge/Label 컴포넌트의 styled-component에 기본적으로 필요한 props입니다
  */
 export interface IBadgeLabelBasicStyle {
-  $feedback: keyof IBadgeLabelFeedbackColor;
+  $feedback: BadgeLabelFeedback;
   $style: keyof IStyle;
   $size: keyof typeof BADGE_LABEL_SIZE;
 }

--- a/src/components/ContextMenu/Combobox.style.ts
+++ b/src/components/ContextMenu/Combobox.style.ts
@@ -1,0 +1,46 @@
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const Combobox = styled.div`
+  width: 25rem;
+  max-height: 21rem;
+
+  display: flex;
+  align-items: flex-start;
+  gap: ${DESIGN_SYSTEM.gap["3xs"]};
+  padding: ${DESIGN_SYSTEM.gap["3xs"]};
+
+  border-radius: ${DESIGN_SYSTEM.radius.md};
+  border: ${DESIGN_SYSTEM.stroke.normal} solid
+    ${({ theme }) => theme.light["border-trans-subtler"]};
+
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+  background: ${({ theme }) => theme.light["surface-embossed"]};
+
+  ${DESIGN_SYSTEM.shadow.floated}
+
+  overflow: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const ItemContainer = styled.div`
+  max-height: 20rem;
+
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  align-items: flex-start;
+  gap: ${DESIGN_SYSTEM.gap.none};
+  padding: ${DESIGN_SYSTEM.gap.none};
+  flex: 1 0 0;
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+
+  overflow: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/src/components/ContextMenu/Combobox.tsx
+++ b/src/components/ContextMenu/Combobox.tsx
@@ -1,0 +1,13 @@
+import { IContextMenu } from "./ContextMenu.types";
+import * as S from "./Combobox.style";
+
+export default function Combobox({ children }: IContextMenu) {
+  return (
+    <S.Combobox>
+      <S.ItemContainer>
+        {children}
+        {/* TODO: fade 컴포넌트 구현 후 추가하기 */}
+      </S.ItemContainer>
+    </S.Combobox>
+  );
+}

--- a/src/components/ContextMenu/ContextMenu.style.ts
+++ b/src/components/ContextMenu/ContextMenu.style.ts
@@ -17,6 +17,11 @@ export const ContextMenu = styled.div`
   background: ${({ theme }) => theme.light["surface-floated"]};
 
   ${DESIGN_SYSTEM.shadow.floated}
+
+  overflow: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const ItemContainer = styled.div`
@@ -32,4 +37,9 @@ export const ItemContainer = styled.div`
 
   border-radius: ${DESIGN_SYSTEM.radius.none};
   opacity: ${DESIGN_SYSTEM.opacity.visible};
+
+  overflow: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/src/components/ContextMenu/ContextMenu.style.ts
+++ b/src/components/ContextMenu/ContextMenu.style.ts
@@ -1,0 +1,35 @@
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const ContextMenu = styled.div`
+  width: 11.875rem;
+  max-height: 21rem;
+
+  display: flex;
+  align-items: flex-start;
+  gap: ${DESIGN_SYSTEM.gap["3xs"]};
+  padding: ${DESIGN_SYSTEM.gap["3xs"]};
+
+  border-radius: ${DESIGN_SYSTEM.radius.md};
+  border: ${DESIGN_SYSTEM.stroke.normal} solid
+    ${({ theme }) => theme.light["border-trans-subtler"]};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+  background: ${({ theme }) => theme.light["surface-floated"]};
+
+  ${DESIGN_SYSTEM.shadow.floated}
+`;
+
+export const ItemContainer = styled.div`
+  max-height: 20rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  padding: ${DESIGN_SYSTEM.gap.none};
+  gap: ${DESIGN_SYSTEM.gap.none};
+  flex: 1 0 0;
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;

--- a/src/components/ContextMenu/ContextMenu.theme.ts
+++ b/src/components/ContextMenu/ContextMenu.theme.ts
@@ -1,4 +1,7 @@
 import DESIGN_SYSTEM from "@/styles/designSystem";
+import { DefaultTheme } from "styled-components";
+import { InteractionVariant } from "../Interaction/Interaction.types";
+import { BadgeLabelFeedback } from "../Badge/Badge.types";
 
 export const CONTEXT_MENU_ITEM_SIZE = {
   sm: {
@@ -24,5 +27,25 @@ export const CONTEXT_MENU_ITEM_SIZE = {
     badge: { width: "11.1875rem", height: "5.6875rem" },
     itemLabelText: DESIGN_SYSTEM.typography.label.md,
     iconSize: DESIGN_SYSTEM.iconSize.md,
+  },
+};
+
+export const CONTEXT_MENU_ITEM_FEEDBACK_COLOR = {
+  normal: {
+    itemLabelTextColor: (theme: DefaultTheme) => theme.light["object-boldest"],
+    interaction: InteractionVariant.DEFAULT,
+    label: BadgeLabelFeedback.NONE,
+  },
+  info: {
+    itemLabelTextColor: (theme: DefaultTheme) =>
+      theme.light["feedback-information"],
+    interaction: InteractionVariant.INFO,
+    label: BadgeLabelFeedback.INFO,
+  },
+  negative: {
+    itemLabelTextColor: (theme: DefaultTheme) =>
+      theme.light["feedback-negative"],
+    interaction: InteractionVariant.NEGATIVE,
+    label: BadgeLabelFeedback.NEGATIVE,
   },
 };

--- a/src/components/ContextMenu/ContextMenu.theme.ts
+++ b/src/components/ContextMenu/ContextMenu.theme.ts
@@ -1,0 +1,28 @@
+import DESIGN_SYSTEM from "@/styles/designSystem";
+
+export const CONTEXT_MENU_ITEM_SIZE = {
+  sm: {
+    labelOnly: {
+      width: "6.3125rem",
+      height: "5rem",
+    },
+    checkbox: { width: "7.9375rem", height: "5rem" },
+    leftIcon: { width: "7.9375rem", height: "5rem" },
+    rightIcon: { width: "7.9375rem", height: "5rem" },
+    badge: { width: "10.0625rem", height: "5.125rem" },
+    itemLabelText: DESIGN_SYSTEM.typography.label.xs,
+    iconSize: DESIGN_SYSTEM.iconSize.xs,
+  },
+  md: {
+    labelOnly: {
+      width: "7.4375rem",
+      height: "5.6875rem",
+    },
+    checkbox: { width: "9.3125rem", height: "5.6875rem" },
+    leftIcon: { width: "9.3125rem", height: "5.6875rem" },
+    rightIcon: { width: "9.3125rem", height: "5.6875rem" },
+    badge: { width: "11.1875rem", height: "5.6875rem" },
+    itemLabelText: DESIGN_SYSTEM.typography.label.md,
+    iconSize: DESIGN_SYSTEM.iconSize.md,
+  },
+};

--- a/src/components/ContextMenu/ContextMenu.theme.ts
+++ b/src/components/ContextMenu/ContextMenu.theme.ts
@@ -5,26 +5,10 @@ import { BadgeLabelFeedback } from "../Badge/Badge.types";
 
 export const CONTEXT_MENU_ITEM_SIZE = {
   sm: {
-    labelOnly: {
-      width: "6.3125rem",
-      height: "5rem",
-    },
-    checkbox: { width: "7.9375rem", height: "5rem" },
-    leftIcon: { width: "7.9375rem", height: "5rem" },
-    rightIcon: { width: "7.9375rem", height: "5rem" },
-    badge: { width: "10.0625rem", height: "5.125rem" },
     itemLabelText: DESIGN_SYSTEM.typography.label.xs,
     iconSize: DESIGN_SYSTEM.iconSize.xs,
   },
   md: {
-    labelOnly: {
-      width: "7.4375rem",
-      height: "5.6875rem",
-    },
-    checkbox: { width: "9.3125rem", height: "5.6875rem" },
-    leftIcon: { width: "9.3125rem", height: "5.6875rem" },
-    rightIcon: { width: "9.3125rem", height: "5.6875rem" },
-    badge: { width: "11.1875rem", height: "5.6875rem" },
     itemLabelText: DESIGN_SYSTEM.typography.label.md,
     iconSize: DESIGN_SYSTEM.iconSize.md,
   },

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import * as S from "./ContextMenu.style";
+import ContextMenuItem from "./ContextMenuItem";
+
+export default function ContextMenu({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <S.ContextMenu>
+      <S.ItemContainer>
+        {children}
+        {/* TODO: Fade 컴포넌트 구현 후 추가하기 */}
+      </S.ItemContainer>
+    </S.ContextMenu>
+  );
+}
+
+ContextMenu.Item = ContextMenuItem;

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import * as S from "./ContextMenu.style";
 import ContextMenuItem from "./ContextMenuItem";
+import { IContextMenu } from "./ContextMenu.types";
 
-export default function ContextMenu({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function ContextMenu({ children }: IContextMenu) {
   return (
     <S.ContextMenu>
       <S.ItemContainer>

--- a/src/components/ContextMenu/ContextMenu.types.ts
+++ b/src/components/ContextMenu/ContextMenu.types.ts
@@ -1,0 +1,17 @@
+import {
+  CONTEXT_MENU_ITEM_FEEDBACK_COLOR,
+  CONTEXT_MENU_ITEM_SIZE,
+} from "./ContextMenu.theme";
+
+export interface IContextMenuItemStyle {
+  $variant: "labelOnly" | "checkbox" | "leftIcon" | "rightIcon" | "badge";
+  $size: keyof typeof CONTEXT_MENU_ITEM_SIZE;
+  $feedback?: keyof typeof CONTEXT_MENU_ITEM_FEEDBACK_COLOR;
+}
+
+export interface IContextMenuItem extends IContextMenuItemStyle {
+  labelText: string;
+  subLabelText?: string;
+  captionText?: string;
+  badgeLabelText?: string;
+}

--- a/src/components/ContextMenu/ContextMenu.types.ts
+++ b/src/components/ContextMenu/ContextMenu.types.ts
@@ -15,3 +15,7 @@ export interface IContextMenuItem extends IContextMenuItemStyle {
   captionText?: string;
   badgeLabelText?: string;
 }
+
+export interface IContextMenu {
+  children: React.ReactNode;
+}

--- a/src/components/ContextMenu/ContextMenuItem.style.ts
+++ b/src/components/ContextMenu/ContextMenuItem.style.ts
@@ -6,12 +6,7 @@ import {
   CONTEXT_MENU_ITEM_FEEDBACK_COLOR,
   CONTEXT_MENU_ITEM_SIZE,
 } from "./ContextMenu.theme";
-
-export interface IContextMenuItemStyle {
-  $variant: "labelOnly" | "checkbox" | "leftIcon" | "rightIcon" | "badge";
-  $size: keyof typeof CONTEXT_MENU_ITEM_SIZE;
-  $feedback?: keyof typeof CONTEXT_MENU_ITEM_FEEDBACK_COLOR;
-}
+import { IContextMenuItemStyle } from "./ContextMenu.types";
 
 export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
   position: relative;

--- a/src/components/ContextMenu/ContextMenuItem.style.ts
+++ b/src/components/ContextMenu/ContextMenuItem.style.ts
@@ -1,0 +1,106 @@
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+import { CONTEXT_MENU_ITEM_SIZE } from "./ContextMenu.theme";
+import checkboxBlankLine from "@/assets/icons/checkbox-blank-line.svg";
+import blankLine from "@/assets/icons/blank-line.svg";
+
+export interface IContextMenuItemStyle {
+  $variant: "labelOnly" | "checkbox" | "leftIcon" | "rightIcon" | "badge";
+  $size: keyof typeof CONTEXT_MENU_ITEM_SIZE;
+}
+
+export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
+  position: relative;
+
+  width: ${(props) =>
+    CONTEXT_MENU_ITEM_SIZE[props.$size][props.$variant].width};
+  height: ${(props) =>
+    CONTEXT_MENU_ITEM_SIZE[props.$size][props.$variant].height};
+
+  display: inline-flex;
+  align-items: center;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.xs} ${DESIGN_SYSTEM.gap.md};
+
+  border-radius: ${DESIGN_SYSTEM.radius.xs};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const ContextMenuCheckboxIcon = styled(
+  checkboxBlankLine
+)<IContextMenuItemStyle>`
+  width: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
+  height: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
+
+  path {
+    fill: ${({ theme }) => theme.light["object-subtle"]};
+  }
+`;
+
+export const ContextMenuBlankLine = styled(blankLine)<IContextMenuItemStyle>`
+  width: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
+  height: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
+
+  path {
+    fill: ${({ theme }) => theme.light["object-subtle"]};
+  }
+`;
+
+export const ContextMenuItemSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${DESIGN_SYSTEM.gap["6xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const ContextMenuItemWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${DESIGN_SYSTEM.gap["7xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const ContextMenuItemContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${DESIGN_SYSTEM.gap["3xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const ContextMenuItemLabelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: ${DESIGN_SYSTEM.gap.none};
+  gap: ${DESIGN_SYSTEM.gap["7xs"]};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const ContextMenuItemItemLabelText = styled.span<IContextMenuItemStyle>`
+  color: ${({ theme }) => theme.light["object-boldest"]};
+
+  ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].itemLabelText};
+`;
+
+export const ContextMenuItemSubLabelText = styled.span`
+  color: ${({ theme }) => theme.light["object-normal"]};
+  ${DESIGN_SYSTEM.typography.body.xs};
+`;
+
+export const ContextMenuItemCaptionText = styled.span`
+  color: ${({ theme }) => theme.light["object-subtler"]};
+  ${DESIGN_SYSTEM.typography.body["2xs"]};
+`;

--- a/src/components/ContextMenu/ContextMenuItem.style.ts
+++ b/src/components/ContextMenu/ContextMenuItem.style.ts
@@ -1,21 +1,25 @@
 import DESIGN_SYSTEM from "@/styles/designSystem";
 import styled from "styled-components";
-import { CONTEXT_MENU_ITEM_SIZE } from "./ContextMenu.theme";
 import checkboxBlankLine from "@/assets/icons/checkbox-blank-line.svg";
 import blankLine from "@/assets/icons/blank-line.svg";
+import {
+  CONTEXT_MENU_ITEM_FEEDBACK_COLOR,
+  CONTEXT_MENU_ITEM_SIZE,
+} from "./ContextMenu.theme";
 
 export interface IContextMenuItemStyle {
   $variant: "labelOnly" | "checkbox" | "leftIcon" | "rightIcon" | "badge";
   $size: keyof typeof CONTEXT_MENU_ITEM_SIZE;
+  $feedback?: keyof typeof CONTEXT_MENU_ITEM_FEEDBACK_COLOR;
 }
 
 export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
   position: relative;
 
-  width: ${(props) =>
-    CONTEXT_MENU_ITEM_SIZE[props.$size][props.$variant].width};
-  height: ${(props) =>
-    CONTEXT_MENU_ITEM_SIZE[props.$size][props.$variant].height};
+  width: ${({ $variant, $size }) =>
+    CONTEXT_MENU_ITEM_SIZE[$size][$variant].width};
+  height: ${({ $variant, $size }) =>
+    CONTEXT_MENU_ITEM_SIZE[$size][$variant].height};
 
   display: inline-flex;
   align-items: center;
@@ -29,8 +33,8 @@ export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
 export const ContextMenuCheckboxIcon = styled(
   checkboxBlankLine
 )<IContextMenuItemStyle>`
-  width: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
-  height: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
+  width: ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].iconSize};
+  height: ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].iconSize};
 
   path {
     fill: ${({ theme }) => theme.light["object-subtle"]};
@@ -38,8 +42,8 @@ export const ContextMenuCheckboxIcon = styled(
 `;
 
 export const ContextMenuBlankLine = styled(blankLine)<IContextMenuItemStyle>`
-  width: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
-  height: ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].iconSize};
+  width: ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].iconSize};
+  height: ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].iconSize};
 
   path {
     fill: ${({ theme }) => theme.light["object-subtle"]};
@@ -90,9 +94,11 @@ export const ContextMenuItemLabelContainer = styled.div`
 `;
 
 export const ContextMenuItemItemLabelText = styled.span<IContextMenuItemStyle>`
-  color: ${({ theme }) => theme.light["object-boldest"]};
+  color: ${({ $feedback, theme }) =>
+    $feedback &&
+    CONTEXT_MENU_ITEM_FEEDBACK_COLOR[$feedback].itemLabelTextColor(theme)};
 
-  ${(props) => CONTEXT_MENU_ITEM_SIZE[props.$size].itemLabelText};
+  ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].itemLabelText};
 `;
 
 export const ContextMenuItemSubLabelText = styled.span`

--- a/src/components/ContextMenu/ContextMenuItem.style.ts
+++ b/src/components/ContextMenu/ContextMenuItem.style.ts
@@ -11,10 +11,8 @@ import { IContextMenuItemStyle } from "./ContextMenu.types";
 export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
   position: relative;
 
-  width: ${({ $variant, $size }) =>
-    CONTEXT_MENU_ITEM_SIZE[$size][$variant].width};
-  height: ${({ $variant, $size }) =>
-    CONTEXT_MENU_ITEM_SIZE[$size][$variant].height};
+  width: 100%;
+  height: fit-content;
 
   display: inline-flex;
   align-items: center;
@@ -46,6 +44,9 @@ export const ContextMenuBlankLine = styled(blankLine)<IContextMenuItemStyle>`
 `;
 
 export const ContextMenuItemSection = styled.div`
+  width: fit-content;
+  height: fit-content;
+
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -78,6 +79,9 @@ export const ContextMenuItemContainer = styled.div`
 `;
 
 export const ContextMenuItemLabelContainer = styled.div`
+  width: fit-content;
+  height: fit-content;
+
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/src/components/ContextMenu/ContextMenuItem.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import * as S from "./ContextMenuItem.style";
+import InteractionContainer from "../Interaction/Interaction.style";
+import BadgeLabel from "../Badge/Badge.Label";
+
+interface IContextMenuItem extends S.IContextMenuItemStyle {
+  labelText: string;
+  subLabelText?: string;
+  captionText?: string;
+  badgeLabelText?: string;
+}
+
+export default function ContextMenuItem({
+  $variant,
+  $size,
+  labelText,
+  subLabelText,
+  captionText,
+  badgeLabelText,
+}: IContextMenuItem) {
+  return (
+    <S.ContextMenuItem $variant={$variant} $size={$size}>
+      {$variant === "checkbox" && (
+        <S.ContextMenuCheckboxIcon $variant={$variant} $size={$size} />
+      )}
+      {$variant === "leftIcon" && (
+        <S.ContextMenuBlankLine $variant={$variant} $size={$size} />
+      )}
+      <S.ContextMenuItemSection>
+        {$variant === "badge" ? (
+          <S.ContextMenuItemWrap>
+            <S.ContextMenuItemContainer>
+              <S.ContextMenuItemItemLabelText $variant={$variant} $size={$size}>
+                {labelText}
+              </S.ContextMenuItemItemLabelText>
+              <BadgeLabel
+                $variant="labelOnly"
+                $feedback="none"
+                $style="transparent"
+                $size="xs"
+                text={badgeLabelText || "레이블"}
+              />
+            </S.ContextMenuItemContainer>
+            {subLabelText && (
+              <S.ContextMenuItemSubLabelText>
+                {subLabelText}
+              </S.ContextMenuItemSubLabelText>
+            )}
+          </S.ContextMenuItemWrap>
+        ) : (
+          <S.ContextMenuItemLabelContainer>
+            <S.ContextMenuItemItemLabelText $variant={$variant} $size={$size}>
+              {labelText}
+            </S.ContextMenuItemItemLabelText>
+            {subLabelText && (
+              <S.ContextMenuItemSubLabelText>
+                {subLabelText}
+              </S.ContextMenuItemSubLabelText>
+            )}
+          </S.ContextMenuItemLabelContainer>
+        )}
+        {captionText && (
+          <S.ContextMenuItemCaptionText>
+            {captionText}
+          </S.ContextMenuItemCaptionText>
+        )}
+      </S.ContextMenuItemSection>
+      {$variant === "rightIcon" && (
+        <S.ContextMenuBlankLine $variant={$variant} $size={$size} />
+      )}
+      <InteractionContainer $variant="default" $density="normal" />
+    </S.ContextMenuItem>
+  );
+}

--- a/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/src/components/ContextMenu/ContextMenuItem.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as S from "./ContextMenuItem.style";
 import InteractionContainer from "../Interaction/Interaction.style";
 import BadgeLabel from "../Badge/Badge.Label";
+import { CONTEXT_MENU_ITEM_FEEDBACK_COLOR } from "./ContextMenu.theme";
 
 interface IContextMenuItem extends S.IContextMenuItemStyle {
   labelText: string;
@@ -13,6 +14,7 @@ interface IContextMenuItem extends S.IContextMenuItemStyle {
 export default function ContextMenuItem({
   $variant,
   $size,
+  $feedback = "normal",
   labelText,
   subLabelText,
   captionText,
@@ -30,12 +32,16 @@ export default function ContextMenuItem({
         {$variant === "badge" ? (
           <S.ContextMenuItemWrap>
             <S.ContextMenuItemContainer>
-              <S.ContextMenuItemItemLabelText $variant={$variant} $size={$size}>
+              <S.ContextMenuItemItemLabelText
+                $variant={$variant}
+                $size={$size}
+                $feedback={$feedback}
+              >
                 {labelText}
               </S.ContextMenuItemItemLabelText>
               <BadgeLabel
                 $variant="labelOnly"
-                $feedback="none"
+                $feedback={CONTEXT_MENU_ITEM_FEEDBACK_COLOR[$feedback].label}
                 $style="transparent"
                 $size="xs"
                 text={badgeLabelText || "레이블"}
@@ -49,7 +55,11 @@ export default function ContextMenuItem({
           </S.ContextMenuItemWrap>
         ) : (
           <S.ContextMenuItemLabelContainer>
-            <S.ContextMenuItemItemLabelText $variant={$variant} $size={$size}>
+            <S.ContextMenuItemItemLabelText
+              $variant={$variant}
+              $size={$size}
+              $feedback={$feedback}
+            >
               {labelText}
             </S.ContextMenuItemItemLabelText>
             {subLabelText && (
@@ -68,7 +78,10 @@ export default function ContextMenuItem({
       {$variant === "rightIcon" && (
         <S.ContextMenuBlankLine $variant={$variant} $size={$size} />
       )}
-      <InteractionContainer $variant="default" $density="normal" />
+      <InteractionContainer
+        $variant={CONTEXT_MENU_ITEM_FEEDBACK_COLOR[$feedback].interaction}
+        $density="normal"
+      />
     </S.ContextMenuItem>
   );
 }

--- a/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/src/components/ContextMenu/ContextMenuItem.tsx
@@ -3,13 +3,7 @@ import * as S from "./ContextMenuItem.style";
 import InteractionContainer from "../Interaction/Interaction.style";
 import BadgeLabel from "../Badge/Badge.Label";
 import { CONTEXT_MENU_ITEM_FEEDBACK_COLOR } from "./ContextMenu.theme";
-
-interface IContextMenuItem extends S.IContextMenuItemStyle {
-  labelText: string;
-  subLabelText?: string;
-  captionText?: string;
-  badgeLabelText?: string;
-}
+import { IContextMenuItem } from "./ContextMenu.types";
 
 export default function ContextMenuItem({
   $variant,

--- a/src/components/Interaction/Interaction.style.ts
+++ b/src/components/Interaction/Interaction.style.ts
@@ -1,8 +1,9 @@
 import styled, { DefaultTheme } from "styled-components";
 import DESIGN_SYSTEM from "@/styles/designSystem";
+import { InteractionVariant } from "./Interaction.types";
 
 export interface IInteractionContainer {
-  $variant: keyof typeof variantColorMap;
+  $variant: InteractionVariant;
   $density: keyof typeof stateMap;
 }
 

--- a/src/components/Interaction/Interaction.types.ts
+++ b/src/components/Interaction/Interaction.types.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line import/prefer-default-export
+export const enum InteractionVariant {
+  DEFAULT = "default",
+  ACCENT = "accent",
+  INFO = "info",
+  NEGATIVE = "negative",
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,3 +15,4 @@ export { default as Button } from "./Button/Button";
 export { default as IndexPanel } from "./IndexPanel/IndexPanel";
 export { default as Avatar } from "./Avatar/Avatar";
 export { default as ContextMenu } from "./ContextMenu/ContextMenu";
+export { default as Combobox } from "./ContextMenu/Combobox";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,4 +14,4 @@ export { default as CalloutInteractive } from "./Callout/Callout.Interactive";
 export { default as Button } from "./Button/Button";
 export { default as IndexPanel } from "./IndexPanel/IndexPanel";
 export { default as Avatar } from "./Avatar/Avatar";
-export { default as ContextMenuItem } from "./ContextMenu/ContextMenuItem";
+export { default as ContextMenu } from "./ContextMenu/ContextMenu";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,3 +14,4 @@ export { default as CalloutInteractive } from "./Callout/Callout.Interactive";
 export { default as Button } from "./Button/Button";
 export { default as IndexPanel } from "./IndexPanel/IndexPanel";
 export { default as Avatar } from "./Avatar/Avatar";
+export { default as ContextMenuItem } from "./ContextMenu/ContextMenuItem";

--- a/src/stories/ContextMenu/Combobox.stories.tsx
+++ b/src/stories/ContextMenu/Combobox.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Combobox, ContextMenu } from "../../components";
+
+const meta = {
+  title: "Components/ContextMenu/Combobox",
+  component: Combobox,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Combobox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          subLabelText="서브 레이블"
+          $variant="labelOnly"
+          $size="md"
+        />
+      </>
+    ),
+  },
+};

--- a/src/stories/ContextMenu/ContextMenu.stories.tsx
+++ b/src/stories/ContextMenu/ContextMenu.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContextMenu } from "../../components";
+
+const meta = {
+  title: "Components/ContextMenu",
+  component: ContextMenu,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ContextMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+        <ContextMenu.Item
+          labelText="아이템 레이블"
+          $variant="labelOnly"
+          $size="sm"
+        />
+      </>
+    ),
+  },
+};

--- a/src/stories/ContextMenu/ContextMenuItem.stories.tsx
+++ b/src/stories/ContextMenu/ContextMenuItem.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { ContextMenuItem } from "../../components";
+import { ContextMenu } from "../../components";
 
 const meta = {
   title: "Components/ContextMenu/Item",
-  component: ContextMenuItem,
+  component: ContextMenu.Item,
   parameters: {
     layout: "centered",
   },
@@ -22,7 +22,7 @@ const meta = {
       options: ["normal", "info", "negative"],
     },
   },
-} satisfies Meta<typeof ContextMenuItem>;
+} satisfies Meta<typeof ContextMenu.Item>;
 
 export default meta;
 

--- a/src/stories/ContextMenu/ContextMenuItem.stories.tsx
+++ b/src/stories/ContextMenu/ContextMenuItem.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContextMenuItem } from "../../components";
+
+const meta = {
+  title: "Components/ContextMenu/Item",
+  component: ContextMenuItem,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    $variant: {
+      control: { type: "radio" },
+      options: ["labelOnly", "checkbox", "leftIcon", "rightIcon", "badge"],
+    },
+    $size: {
+      control: { type: "radio" },
+      options: ["md", "sm"],
+    },
+  },
+} satisfies Meta<typeof ContextMenuItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    $variant: "labelOnly",
+    $size: "md",
+    labelText: "아이템 레이블",
+    subLabelText: "서브 레이블",
+    captionText: "캡션 텍스트",
+  },
+};
+
+export const Checkbox: Story = {
+  args: {
+    ...Default.args,
+    $variant: "checkbox",
+  },
+};
+
+export const LeftIcon: Story = {
+  args: {
+    ...Default.args,
+    $variant: "leftIcon",
+  },
+};
+
+export const RightIcon: Story = {
+  args: {
+    ...Default.args,
+    $variant: "rightIcon",
+  },
+};
+
+export const Badge: Story = {
+  args: {
+    ...Default.args,
+    $variant: "badge",
+    badgeLabelText: "레이블",
+  },
+};

--- a/src/stories/ContextMenu/ContextMenuItem.stories.tsx
+++ b/src/stories/ContextMenu/ContextMenuItem.stories.tsx
@@ -17,6 +17,10 @@ const meta = {
       control: { type: "radio" },
       options: ["md", "sm"],
     },
+    $feedback: {
+      control: { type: "radio" },
+      options: ["normal", "info", "negative"],
+    },
   },
 } satisfies Meta<typeof ContextMenuItem>;
 


### PR DESCRIPTION
## 🚀 작업 내용

- [x] [ContextMenu 컴포넌트](https://www.figma.com/design/DYKX0B40H5ZVViUtva7HPa/%F0%9F%92%A0%EC%BB%B4%ED%8F%AC%EB%85%B8%ED%8A%B8-%EB%94%94%EC%9E%90%EC%9D%B8-%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=7206-334255&m=dev)를 구현했습니다.
  - [x] `ContextMenu.Item` / `ContextMenu` / `Combobox` 구현 완료

## ✨ 작업 상세 설명

> storybook에서 확인할 수 있습니다.
- ContextMenu 컴포넌트입니다.
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/70811fb3-34fa-408d-b983-2c550e95b2b0" />

> 추가로 ContextMenu.Item과 Combobox 컴포넌트를 개별적으로 확인하실 수 있습니다.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/19d3f8dd-0086-47c4-9b10-7868c5d8acd1" />
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/1a0de5d8-b923-4b3d-b504-c1a86f912c45" />


### 🔥 문제 상황 (선택)

`ContextMenu.Item`의 `width`가 `storybook`과 `local`에서 다르게 나타납니다 ㅠㅠ

- storybook
![image](https://github.com/user-attachments/assets/a88821c9-a48b-470e-9da0-e7371d52c9b1)
- local
![image](https://github.com/user-attachments/assets/d70b5c21-d596-4ed3-8cc3-c7c1e3a1ae76)

### 💦 해결 방법 (선택)
- 일단은 local에서 정상적으로 보이기 때문에 별다른 조치를 취하지 않았습니다. (원인 파악 불가 ㅠㅠ)

## 🔨 추후 수정해야 하는 부분 (선택)
- 추후 Fade 컴포넌트가 만들어지면 추가해줘야할 것 같습니다.
- 현재는 overflow시 scroll되도록 `overflow: auto` 설정을 해뒀고, 스크롤 형태는 숨겨둔 상태입니다!

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
