### PR TITLE
[🐛fix]: focus 인터랙션 분리 (Button 태그에 focus 두번 잡히는 오류 수정)

### DIFF
--- a/src/components/Button/Button.style.tsx
+++ b/src/components/Button/Button.style.tsx
@@ -27,6 +27,10 @@ export const Button = styled.button<IButtonComponent>`
     if (!$buttonStyle) return BUTTON_STYLES.solidBrand(theme);
     return BUTTON_STYLES[$buttonStyle](theme);
   }}
+
+  &:focus-visible {
+    ${({ theme }) => DESIGN_SYSTEM.focus(theme)}
+  }
 `;
 
 export const LabelContainer = styled.div`

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ function renderIcon(
   $buttonType: "button" | "iconButton",
   $buttonStyle: ButtonStyle,
   $size: keyof typeof BUTTON_SIZE_MAP,
-  isVisible: boolean,
+  isVisible: boolean
 ) {
   if (!isVisible || !IconComponent) return null;
 
@@ -44,7 +44,7 @@ export default function Button({
               $buttonType,
               $buttonStyle,
               $size,
-              $isLeftIconVisible,
+              $isLeftIconVisible
             )}
             <S.LabelText $buttonStyle={$buttonStyle} $size={$size}>
               {text}
@@ -54,12 +54,12 @@ export default function Button({
               $buttonType,
               $buttonStyle,
               $size,
-              $isRightIconVisible,
+              $isRightIconVisible
             )}
           </>
         )}
       </S.LabelContainer>
-      <InteractionContainer $variant="default" $density="normal" tabIndex={0} />
+      <InteractionContainer $variant="default" $density="normal" />
     </S.Button>
   );
 }

--- a/src/components/Interaction/Interaction.style.ts
+++ b/src/components/Interaction/Interaction.style.ts
@@ -18,22 +18,16 @@ const stateMap = {
     enabled: DESIGN_SYSTEM.opacity.invisible,
     hover: DESIGN_SYSTEM.opacity[12],
     pressed: DESIGN_SYSTEM.opacity[22],
-    focused: DESIGN_SYSTEM.opacity.visible,
-    disabled: DESIGN_SYSTEM.opacity.invisible,
   },
   normal: {
     enabled: DESIGN_SYSTEM.opacity.invisible,
     hover: DESIGN_SYSTEM.opacity[8],
     pressed: DESIGN_SYSTEM.opacity[16],
-    focused: DESIGN_SYSTEM.opacity.visible,
-    disabled: DESIGN_SYSTEM.opacity.invisible,
   },
   subtle: {
     enabled: DESIGN_SYSTEM.opacity.invisible,
     hover: DESIGN_SYSTEM.opacity[5],
     pressed: DESIGN_SYSTEM.opacity[12],
-    focused: DESIGN_SYSTEM.opacity.visible,
-    disabled: DESIGN_SYSTEM.opacity.invisible,
   },
 };
 
@@ -59,13 +53,6 @@ const InteractionContainer = styled.span<IInteractionContainer>`
 
   &:active {
     opacity: ${(props) => stateMap[props.$density].pressed};
-  }
-
-  &:focus-visible {
-    outline: ${({ theme }) =>
-      `${DESIGN_SYSTEM.stroke.bolder} solid ${theme.light["interactive-focus"]}`};
-    opacity: ${(props) => stateMap[props.$density].focused};
-    background-color: transparent;
   }
 `;
 

--- a/src/styles/designSystem.tsx
+++ b/src/styles/designSystem.tsx
@@ -1,3 +1,5 @@
+import { DefaultTheme } from "styled-components";
+
 const alpha = {
   1: "rgba(9, 11, 18, 0.01)",
   2: "rgba(9, 11, 18, 0.02)",
@@ -242,6 +244,11 @@ const shadow = {
   0 0.5rem 1rem 0 ${alpha[16]}`,
 };
 
+const focus = (theme: DefaultTheme) => `
+    outline: 
+      ${stroke.bolder} solid ${theme.light["interactive-focus"]};
+  `;
+
 const DESIGN_SYSTEM = {
   alpha,
   typography,
@@ -251,5 +258,6 @@ const DESIGN_SYSTEM = {
   stroke,
   opacity,
   shadow,
+  focus,
 };
 export default DESIGN_SYSTEM;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] focus 인터랙션을 `Interaction` 컴포넌트에서 제거하고 `DESIGN_SYSTEM`에 저장함

## ✨ 작업 상세 설명

### 🔥 문제 상황 (선택)
- `button` 태그에 `Interaction` 컴포넌트를 입힐 시에, `focus`가 `button`태그에 한번, `Interaction` 컴포넌트에 한번, 총 두번 입혀지는 문제 발견 
- 이는 사용자 경험을 매우 저해하는 일이므로 해결이 필요

### 💦 해결 방법 (선택)

- `Interaction` 컴포넌트에 있던 `focus` 스타일을 `DESIGN_SYSTEM` 객체에 저장하고, `Interaction` 컴포넌트는 `hover`, `active`만 조절하도록 함.

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
