### PR TITLE
[📝docs]: Fade 컴포넌트 deprecated / 임시 랜딩페이지 제작

### DIFF
--- a/src/app/_components/Home.style.ts
+++ b/src/app/_components/Home.style.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const HomeWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+  background: ${({ theme }) => theme.light["surface-standard"]};
+`;
+
+export const HomeViewport = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+`;

--- a/src/app/_components/HomeBanner.style.ts
+++ b/src/app/_components/HomeBanner.style.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const HomeBannerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["8xl"]};
+  padding: ${DESIGN_SYSTEM.gap["7xl"]};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+  background: ${({ theme }) => theme.light["surface-standard"]};
+`;
+
+export const HomeBannerContent = styled.div`
+  height: 26rem;
+  max-width: 90rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: ${DESIGN_SYSTEM.gap["8xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+  flex: 1 0 0;
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerModule = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["4xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerRegion = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["3xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerCardList = styled.div`
+  max-width: 90rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none} ${DESIGN_SYSTEM.gap["4xl"]};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerSectionWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["5xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerTitleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.none};
+  padding-left: ${DESIGN_SYSTEM.gap["4xs"]};
+
+  border-radius: ${DESIGN_SYSTEM.radius.none};
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerTitleText = styled.span`
+  flex: 1 0 0;
+  color: ${({ theme }) => theme.light["object-bolder"]};
+  text-align: center;
+
+  ${DESIGN_SYSTEM.typography.title[2]}
+`;
+
+export const HomeBannerDisplayText = styled.span`
+  align-self: stretch;
+  color: ${({ theme }) => theme.light["object-hero"]};
+
+  text-align: center;
+  font-family: "Elice DigitalBaeum OTF";
+  font-size: 3.5rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 4.55rem;
+  letter-spacing: -0.049rem;
+
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;
+
+export const HomeBannerBodyText = styled.span`
+  align-self: stretch;
+
+  color: ${({ theme }) => theme.light["object-bolder"]};
+  text-align: center;
+
+  ${DESIGN_SYSTEM.typography.body.md}
+
+  opacity: ${DESIGN_SYSTEM.opacity.visible};
+`;

--- a/src/app/_components/HomeBanner.tsx
+++ b/src/app/_components/HomeBanner.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import rightLine from "@/assets/icons/chevron-right-line.svg";
+import * as S from "./HomeBanner.style";
+
+export default function HomeBanner() {
+  return (
+    <S.HomeBannerWrapper>
+      <S.HomeBannerContent>
+        <S.HomeBannerModule>
+          <S.HomeBannerRegion>
+            <S.HomeBannerSection>
+              <S.HomeBannerSectionWrap>
+                <S.HomeBannerTitleContainer>
+                  <S.HomeBannerTitleText>
+                    사용자 인터페이스를 위한
+                  </S.HomeBannerTitleText>
+                </S.HomeBannerTitleContainer>
+                <S.HomeBannerDisplayText>
+                  컴포넌트 저장소
+                </S.HomeBannerDisplayText>
+              </S.HomeBannerSectionWrap>
+              <S.HomeBannerBodyText>
+                컴포노트는 UI를 디자인하고 개발하는 데에 사용되는 컴포넌트에
+                대한 정보를 소개합니다. 여러 직군들이 컴포넌트를 어떻게
+                디자인하고 개발하는지 경험을 나눌 수 있어요.
+              </S.HomeBannerBodyText>
+            </S.HomeBannerSection>
+            <Button
+              text="컴포넌트 목록 보러가기"
+              $rightIcon={rightLine}
+              $isLeftIconVisible={false}
+              $isRightIconVisible
+              $size="md"
+              $buttonStyle={ButtonStyle.SolidBrand}
+            />
+          </S.HomeBannerRegion>
+          <S.HomeBannerCardList>card</S.HomeBannerCardList>
+        </S.HomeBannerModule>
+      </S.HomeBannerContent>
+    </S.HomeBannerWrapper>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,19 @@
+import { Footer, NavigationBar } from "@/components";
+import * as S from "./_components/Home.style";
+import HomeBanner from "./_components/HomeBanner";
+
 export default function Home() {
-  return <div className="bg-light-fillNormal">Home</div>;
+  return (
+    <S.HomeWrapper>
+      <NavigationBar
+        $isSeparated={false}
+        $isAuthorized={false}
+        placeholderText="플레이스 홀더"
+      />
+      <S.HomeViewport>
+        <HomeBanner />
+      </S.HomeViewport>
+      <Footer />
+    </S.HomeWrapper>
+  );
 }

--- a/src/components/ContextMenu/Combobox.tsx
+++ b/src/components/ContextMenu/Combobox.tsx
@@ -4,10 +4,7 @@ import * as S from "./Combobox.style";
 export default function Combobox({ children }: IContextMenu) {
   return (
     <S.Combobox>
-      <S.ItemContainer>
-        {children}
-        {/* TODO: fade 컴포넌트 구현 후 추가하기 */}
-      </S.ItemContainer>
+      <S.ItemContainer>{children}</S.ItemContainer>
     </S.Combobox>
   );
 }

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -6,10 +6,7 @@ import { IContextMenu } from "./ContextMenu.types";
 export default function ContextMenu({ children }: IContextMenu) {
   return (
     <S.ContextMenu>
-      <S.ItemContainer>
-        {children}
-        {/* TODO: Fade 컴포넌트 구현 후 추가하기 */}
-      </S.ItemContainer>
+      <S.ItemContainer>{children}</S.ItemContainer>
     </S.ContextMenu>
   );
 }

--- a/src/stories/Badge/Badge.ComponentType.stories.tsx
+++ b/src/stories/Badge/Badge.ComponentType.stories.tsx
@@ -6,6 +6,9 @@ const meta = {
   title: "Components/Badge/ComponentType",
   tags: ["autodocs"],
   excludeStories: /.*Data$/,
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     $type: {
       options: ["input", "display", "feedback", "navigation"],

--- a/src/stories/Badge/Badge.Label.stories.tsx
+++ b/src/stories/Badge/Badge.Label.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { BadgeLabelFeedback } from "@/components/Badge/Badge.types";
 import { BadgeLabel } from "../../components";
 
 const meta = {
@@ -6,6 +7,9 @@ const meta = {
   title: "Components/Badge/Label",
   tags: ["autodocs"],
   excludeStories: /.*Data$/,
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     $variant: {
       options: ["labelOnly", "rightIcon"],
@@ -34,7 +38,7 @@ export const Default: Story = {
   args: {
     $variant: "labelOnly",
     text: "레이블",
-    $feedback: "none",
+    $feedback: BadgeLabelFeedback.NONE,
     $style: "solid",
     $size: "md",
   },
@@ -80,14 +84,14 @@ export const IconNoneOutlined: Story = {
 export const LabelNegativeSolid: Story = {
   args: {
     ...Default.args,
-    $feedback: "negative",
+    $feedback: BadgeLabelFeedback.NEGATIVE,
   },
 };
 
 export const IconNegativeSolid: Story = {
   args: {
     ...Default.args,
-    $feedback: "negative",
+    $feedback: BadgeLabelFeedback.NEGATIVE,
     $variant: "rightIcon",
   },
 };
@@ -95,7 +99,7 @@ export const IconNegativeSolid: Story = {
 export const LabelNegativeTransparent: Story = {
   args: {
     ...Default.args,
-    $feedback: "negative",
+    $feedback: BadgeLabelFeedback.NEGATIVE,
     $style: "transparent",
   },
 };
@@ -103,7 +107,7 @@ export const LabelNegativeTransparent: Story = {
 export const IconNegativeTransparent: Story = {
   args: {
     ...Default.args,
-    $feedback: "negative",
+    $feedback: BadgeLabelFeedback.NEGATIVE,
     $style: "transparent",
     $variant: "rightIcon",
   },
@@ -112,7 +116,7 @@ export const IconNegativeTransparent: Story = {
 export const LabelNegativeOutlined: Story = {
   args: {
     ...Default.args,
-    $feedback: "negative",
+    $feedback: BadgeLabelFeedback.NEGATIVE,
     $style: "outlined",
   },
 };
@@ -120,7 +124,7 @@ export const LabelNegativeOutlined: Story = {
 export const IconNegativeOutlined: Story = {
   args: {
     ...Default.args,
-    $feedback: "negative",
+    $feedback: BadgeLabelFeedback.NEGATIVE,
     $style: "outlined",
     $variant: "rightIcon",
   },

--- a/src/stories/Badge/Badge.stories.tsx
+++ b/src/stories/Badge/Badge.stories.tsx
@@ -6,6 +6,9 @@ const meta = {
   title: "Components/Badge",
   tags: ["autodocs"],
   excludeStories: /.*Data$/,
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     $variant: {
       options: ["dot", "new", "count"],

--- a/src/stories/Callout/Callout.Interactive.stories.tsx
+++ b/src/stories/Callout/Callout.Interactive.stories.tsx
@@ -6,6 +6,9 @@ const meta = {
   title: "Components/Callout/Interactive",
   tags: ["autodocs"],
   excludeStories: /.*Data$/,
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     $size: {
       options: ["sm", "md"],

--- a/src/stories/Callout/Callout.stories.tsx
+++ b/src/stories/Callout/Callout.stories.tsx
@@ -6,6 +6,9 @@ const meta = {
   title: "Components/Callout",
   tags: ["autodocs"],
   excludeStories: /.*Data$/,
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     $size: {
       options: ["sm", "md"],


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 임시 랜딩페이지를 제작했습니다.
- [x] Fade 컴포넌트가 deprecated되면서 관련 내용을 제거했습니다.

## ✨ 작업 상세 설명

- 로그인 페이지 작업하기 전, 랜딩페이지가 필요해서 임시로 제작했습니다. 
추후 `Banner` 컴포넌트가 제작되고 랜딩페이지 디자인이 확정되면 싹 수정해도 괜찮습니다!

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3c978519-4087-49e4-8fc9-ca0fccec71ea" />


### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
- 각 페이지마다 `_components`라는 폴더를 만들어서, 그 페이지에서만 사용되는 컴포넌트를 제작하면 어떨까요? 
현재 제작된 컴포넌트를 한번 더 조합해서 페이지에 간단하게만 사용하고 싶을 때 유용할 것 같아서 생각해봤습니다! 의견 부탁드립니다 ☺️
(요거 여쭤보려구 해당 브랜치에 임시 랜딩페이지 제작을 했습니다.. 양해 부탁드립니다 😅)