### PR TITLE
[🐛fix]: Avatar 컴포넌트에 누락된 prop 추가

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -5,13 +5,15 @@ import IAvatar from "./Avatar.types";
 /**
  * 프로필 사진을 보여주는 Avatar 컴포넌트입니다
  */
-export default function Avatar({ $src, $size }: IAvatar) {
+export default function Avatar({ $src, $size, isBadge = true }: IAvatar) {
   return (
     <S.AvatarContainer $size={$size}>
       <S.ImageContainer>
         <S.AvatarImage $src={$src} />
       </S.ImageContainer>
-      <Badge $variant={$size === "sm" || $size === "xs" ? "dot" : "new"} />
+      {isBadge && (
+        <Badge $variant={$size === "sm" || $size === "xs" ? "dot" : "new"} />
+      )}
     </S.AvatarContainer>
   );
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -5,13 +5,13 @@ import IAvatar from "./Avatar.types";
 /**
  * 프로필 사진을 보여주는 Avatar 컴포넌트입니다
  */
-export default function Avatar({ $src, $size, isBadge = true }: IAvatar) {
+export default function Avatar({ $src, $size, badgeVisible = false }: IAvatar) {
   return (
     <S.AvatarContainer $size={$size}>
       <S.ImageContainer>
         <S.AvatarImage $src={$src} />
       </S.ImageContainer>
-      {isBadge && (
+      {badgeVisible && (
         <Badge $variant={$size === "sm" || $size === "xs" ? "dot" : "new"} />
       )}
     </S.AvatarContainer>

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -3,4 +3,5 @@ import AVATAR_SIZE from "./Avatar.theme";
 export default interface IAvatar {
   $src?: string;
   $size: keyof typeof AVATAR_SIZE;
+  isBadge?: boolean;
 }

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -3,5 +3,5 @@ import AVATAR_SIZE from "./Avatar.theme";
 export default interface IAvatar {
   $src?: string;
   $size: keyof typeof AVATAR_SIZE;
-  isBadge?: boolean;
+  badgeVisible?: boolean;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import InteractionContainer from "../Interaction/Interaction.style";
 import { IButton, ButtonStyle } from "./Button.types";
 import * as S from "./Button.style";
 import { BUTTON_SIZE_MAP } from "./Button.theme";
+import { InteractionVariant } from "../Interaction/Interaction.types";
 
 function renderIcon(
   IconComponent: React.ElementType | undefined,
@@ -63,7 +64,10 @@ export default function Button({
           </>
         )}
       </S.LabelContainer>
-      <InteractionContainer $variant="default" $density="normal" />
+      <InteractionContainer
+        $variant={InteractionVariant.DEFAULT}
+        $density="normal"
+      />
     </S.Button>
   );
 }

--- a/src/components/Callout/Callout.Interactive.tsx
+++ b/src/components/Callout/Callout.Interactive.tsx
@@ -1,4 +1,5 @@
 import InteractionContainer from "../Interaction/Interaction.style";
+import { InteractionVariant } from "../Interaction/Interaction.types";
 import * as S from "./Callout.Interactive.style";
 import { ICalloutInteractive } from "./Callout.types";
 
@@ -24,7 +25,10 @@ export default function CalloutInteractive({
           {bodyText}
         </S.CalloutInteractiveBodyText>
       )}
-      <InteractionContainer $variant="default" $density="subtle" />
+      <InteractionContainer
+        $variant={InteractionVariant.DEFAULT}
+        $density="subtle"
+      />
     </S.CalloutInteractiveContainer>
   );
 }

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,6 +1,7 @@
 import * as S from "./Chip.style";
 import InteractionContainer from "../Interaction/Interaction.style";
 import { IChip, IChipComponent } from "./Chip.types";
+import { InteractionVariant } from "../Interaction/Interaction.types";
 
 export default function Chip({
   $isInversed = false,
@@ -34,7 +35,10 @@ export default function Chip({
         <S.CheckLineIconImg $size={$size} $isInversed={$isInversed} />
       )}
       {!$isDisabled && (
-        <InteractionContainer $variant="default" $density="subtle" />
+        <InteractionContainer
+          $variant={InteractionVariant.DEFAULT}
+          $density="subtle"
+        />
       )}
     </S.ChipContainer>
   );

--- a/src/components/IndexPanel/IndexPanel.tsx
+++ b/src/components/IndexPanel/IndexPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import InteractionContainer from "../Interaction/Interaction.style";
 import * as S from "./IndexPanel.style";
+import { InteractionVariant } from "../Interaction/Interaction.types";
 
 /**
  * IndexPanel/Item 컴포넌트에 필요한 props입니다
@@ -33,7 +34,10 @@ function IndexPanelItem({
       onClick={onContentClick}
     >
       {text}
-      <InteractionContainer $variant="default" $density="subtle" />
+      <InteractionContainer
+        $variant={InteractionVariant.DEFAULT}
+        $density="subtle"
+      />
     </S.IndexPanelItem>
   );
 }

--- a/src/components/NavigationBar/NavItem.tsx
+++ b/src/components/NavigationBar/NavItem.tsx
@@ -1,6 +1,7 @@
 import * as S from "./NavItem.style";
 import { INavItem } from "./NavigationBar.types";
 import InteractionContainer from "../Interaction/Interaction.style";
+import { InteractionVariant } from "../Interaction/Interaction.types";
 
 export default function NavItem({ text, href }: INavItem) {
   return (
@@ -8,7 +9,10 @@ export default function NavItem({ text, href }: INavItem) {
       <S.NavItemBox>
         <S.NavItemAnchor href={href}>
           {text}
-          <InteractionContainer $variant="default" $density="subtle" />
+          <InteractionContainer
+            $variant={InteractionVariant.DEFAULT}
+            $density="subtle"
+          />
         </S.NavItemAnchor>
       </S.NavItemBox>
     </S.NavItemContainer>

--- a/src/components/SocialAuth/SocialAuthButton.tsx
+++ b/src/components/SocialAuth/SocialAuthButton.tsx
@@ -1,4 +1,5 @@
 import InteractionContainer from "../Interaction/Interaction.style";
+import { InteractionVariant } from "../Interaction/Interaction.types";
 import * as S from "./SocialAuthButton.style";
 import { SocialAuthIcGithub, SocialAuthIcGoogle } from "./SocialAuthIcon.style";
 
@@ -15,7 +16,10 @@ export default function SocialAuthButton({
     <S.SocialAuthBtn>
       {variant === "google" ? <SocialAuthIcGoogle /> : <SocialAuthIcGithub />}
       <S.SocialAuthLabelText>{labelText}</S.SocialAuthLabelText>
-      <InteractionContainer $variant="default" $density="subtle" />
+      <InteractionContainer
+        $variant={InteractionVariant.DEFAULT}
+        $density="subtle"
+      />
     </S.SocialAuthBtn>
   );
 }

--- a/src/stories/Avatar.stories.tsx
+++ b/src/stories/Avatar.stories.tsx
@@ -20,6 +20,9 @@ const meta = {
       control: { type: "radio" },
       options: ["xs", "sm", "md", "lg", "xl", "2xl"],
     },
+    isBadge: {
+      control: { type: "boolean" },
+    },
   },
 } satisfies Meta<typeof Avatar>;
 


### PR DESCRIPTION

## 🚀 작업 내용


- [x] `isBadge` prop을 추가하여 Badge 를 숨길 수 있도록 수정함
- [x] `Interaction` 컴포넌트가 사용되는 곳에 `InteractionVariant` enum을 사용할 수 있도록 일괄 수정함

## ✨ 작업 상세 설명

- Avatar 컴포넌트에서 Badge를 보이고 안 보이게 설정할 수 있어야 하는데 관련 prop이 부재했음

> storybook에서는 해당 prop을 Boolean형태로 껐다 켰다 할 수 있도록 했습니다
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/a2f84e1c-55d8-4948-9ad4-a84a7eb11d12" />

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
