### PR TITLE
[✨feat]: 회원가입 페이지 UI 완성

### DIFF
--- a/src/app/login/signin/_components/SignIn.style.ts
+++ b/src/app/login/signin/_components/SignIn.style.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const SigninWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex: 1 0 0;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["8xl"]};
+  padding: ${DESIGN_SYSTEM.gap["7xl"]};
+
+  background: ${({ theme }) => theme.light["surface-standard"]};
+`;
+
+export const SigninModule = styled.div`
+  max-width: 35rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  // align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["3xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninBodyModule = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["7xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/app/login/signin/_components/SignInButton/SignInButton.style.ts
+++ b/src/app/login/signin/_components/SignInButton/SignInButton.style.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+// eslint-disable-next-line import/prefer-default-export
+export const SigninButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.md};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/app/login/signin/_components/SignInButton/SignInButton.tsx
+++ b/src/app/login/signin/_components/SignInButton/SignInButton.tsx
@@ -9,15 +9,11 @@ export default function SignInButton() {
         text="취소하기"
         $size="md"
         $buttonStyle={ButtonStyle.OutlinedSecondary}
-        $isLeftIconVisible={false}
-        $isRightIconVisible={false}
       />
       <Button
         text="회원가입 완료"
         $size="md"
         $buttonStyle={ButtonStyle.SolidBrand}
-        $isLeftIconVisible={false}
-        $isRightIconVisible={false}
       />
     </S.SigninButtonContainer>
   );

--- a/src/app/login/signin/_components/SignInButton/SignInButton.tsx
+++ b/src/app/login/signin/_components/SignInButton/SignInButton.tsx
@@ -1,17 +1,18 @@
 import { Button } from "@/components";
 import { ButtonStyle } from "@/components/Button/Button.types";
+import { SIGNIN_TEXT } from "@/constants/messages";
 import * as S from "./SignInButton.style";
 
 export default function SignInButton() {
   return (
     <S.SigninButtonContainer>
       <Button
-        text="취소하기"
+        text={SIGNIN_TEXT.cancelButtonText}
         $size="md"
         $buttonStyle={ButtonStyle.OutlinedSecondary}
       />
       <Button
-        text="회원가입 완료"
+        text={SIGNIN_TEXT.submitButtonText}
         $size="md"
         $buttonStyle={ButtonStyle.SolidBrand}
       />

--- a/src/app/login/signin/_components/SignInButton/SignInButton.tsx
+++ b/src/app/login/signin/_components/SignInButton/SignInButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import * as S from "./SignInButton.style";
+
+export default function SignInButton() {
+  return (
+    <S.SigninButtonContainer>
+      <Button
+        text="취소하기"
+        $size="md"
+        $buttonStyle={ButtonStyle.OutlinedSecondary}
+        $isLeftIconVisible={false}
+        $isRightIconVisible={false}
+      />
+      <Button
+        text="회원가입 완료"
+        $size="md"
+        $buttonStyle={ButtonStyle.SolidBrand}
+        $isLeftIconVisible={false}
+        $isRightIconVisible={false}
+      />
+    </S.SigninButtonContainer>
+  );
+}

--- a/src/app/login/signin/_components/SignInFooter/SignInFooter.style.ts
+++ b/src/app/login/signin/_components/SignInFooter/SignInFooter.style.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const SigninFooterText = styled.span`
+  color: ${({ theme }) => theme.light["object-subtler"]};
+
+  ${DESIGN_SYSTEM.typography.body.xs}
+`;
+
+export const SigninFooterLinkText = styled.a`
+  color: ${({ theme }) => theme.light["object-static-normal"]};
+
+  ${DESIGN_SYSTEM.typography.body.xs}
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-skip-ink: auto;
+  text-decoration-thickness: auto;
+  text-underline-offset: auto;
+  text-underline-position: from-font;
+`;

--- a/src/app/login/signin/_components/SignInFooter/SignInFooter.tsx
+++ b/src/app/login/signin/_components/SignInFooter/SignInFooter.tsx
@@ -1,0 +1,11 @@
+import * as S from "./SignInFooter.style";
+
+export default function SignInFooter() {
+  return (
+    <S.SigninFooterText>
+      회원가입 하시면 <S.SigninFooterLinkText>이용 약관</S.SigninFooterLinkText>
+      과 <S.SigninFooterLinkText>개인정보 처리방침</S.SigninFooterLinkText>에
+      동의하는 것으로 간주돼요.
+    </S.SigninFooterText>
+  );
+}

--- a/src/app/login/signin/_components/SignInJob/SignInJob.style.ts
+++ b/src/app/login/signin/_components/SignInJob/SignInJob.style.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const SigninJobWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninJobTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninJobTitleText = styled.span`
+  align-self: stretch;
+  color: ${({ theme }) => theme.light["object-hero"]};
+
+  ${DESIGN_SYSTEM.typography.title["2"]}
+`;
+
+export const SigninJobTitleMustIcon = styled.span`
+  color: ${({ theme }) => theme.light["feedback-notification"]};
+
+  ${DESIGN_SYSTEM.typography.title["2"]}
+`;
+
+export const SigninJobBodyText = styled.span`
+  align-self: stretch;
+  color: ${({ theme }) => theme.light["object-bold"]};
+
+  ${DESIGN_SYSTEM.typography.body.sm}
+`;
+
+export const SigninJobChipContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  align-content: flex-start;
+  align-self: stretch;
+  flex-wrap: wrap;
+  gap: ${DESIGN_SYSTEM.gap.xs};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/app/login/signin/_components/SignInJob/SignInJob.tsx
+++ b/src/app/login/signin/_components/SignInJob/SignInJob.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Chip } from "@/components";
+import { useState } from "react";
+import * as S from "./SignInJob.style";
+
+export default function SignInJob() {
+  const [selectedChip, setSelectedChip] = useState<number | null>(null);
+
+  const chips = ["기획자", "개발자", "디자이너", "마케터", "기타 직군"];
+  return (
+    <S.SigninJobWrapper>
+      <S.SigninJobTitleContainer>
+        <S.SigninJobTitleText>
+          직군을 선택해 주세요.
+          <S.SigninJobTitleMustIcon>*</S.SigninJobTitleMustIcon>
+        </S.SigninJobTitleText>
+        <S.SigninJobBodyText>
+          여러 직군을 겸하고 계신다면, 가장 가까운 직군을 골라주세요.
+        </S.SigninJobBodyText>
+      </S.SigninJobTitleContainer>
+      <S.SigninJobChipContainer>
+        {chips.map((chip, i) => (
+          <Chip
+            text={chip}
+            onClick={() => setSelectedChip(i)}
+            $isSelected={i === selectedChip}
+            key={`${chip}i`}
+            $size="xl"
+          />
+        ))}
+      </S.SigninJobChipContainer>
+    </S.SigninJobWrapper>
+  );
+}

--- a/src/app/login/signin/_components/SignInJob/SignInJob.tsx
+++ b/src/app/login/signin/_components/SignInJob/SignInJob.tsx
@@ -2,25 +2,24 @@
 
 import { Chip } from "@/components";
 import { useState } from "react";
+import { SIGNIN_TEXT, STAR_ICON } from "@/constants/messages";
+import { SIGNIN_CHIPS } from "@/constants/chips";
 import * as S from "./SignInJob.style";
 
 export default function SignInJob() {
   const [selectedChip, setSelectedChip] = useState<number | null>(null);
 
-  const chips = ["기획자", "개발자", "디자이너", "마케터", "기타 직군"];
   return (
     <S.SigninJobWrapper>
       <S.SigninJobTitleContainer>
         <S.SigninJobTitleText>
-          직군을 선택해 주세요.
-          <S.SigninJobTitleMustIcon>*</S.SigninJobTitleMustIcon>
+          {SIGNIN_TEXT.job.titleText}
+          <S.SigninJobTitleMustIcon>{STAR_ICON}</S.SigninJobTitleMustIcon>
         </S.SigninJobTitleText>
-        <S.SigninJobBodyText>
-          여러 직군을 겸하고 계신다면, 가장 가까운 직군을 골라주세요.
-        </S.SigninJobBodyText>
+        <S.SigninJobBodyText>{SIGNIN_TEXT.job.bodyText}</S.SigninJobBodyText>
       </S.SigninJobTitleContainer>
       <S.SigninJobChipContainer>
-        {chips.map((chip, i) => (
+        {SIGNIN_CHIPS.map((chip, i) => (
           <Chip
             text={chip}
             onClick={() => setSelectedChip(i)}

--- a/src/app/login/signin/_components/SignInProfile/SignInProfile.style.ts
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfile.style.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const SigninProfileWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninProfileTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  align-self: stretch;
+
+  color: ${({ theme }) => theme.light["object-hero"]};
+
+  ${DESIGN_SYSTEM.typography.title["2"]}
+`;
+
+export const SigninProfileInputSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["7xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/app/login/signin/_components/SignInProfile/SignInProfile.tsx
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfile.tsx
@@ -1,0 +1,17 @@
+import * as S from "./SignInProfile.style";
+import SignInProfileImage from "./SignInProfileImage";
+import SignInProfileNickname from "./SignInProfileNickname";
+
+export default function SignInProfile() {
+  return (
+    <S.SigninProfileWrapper>
+      <S.SigninProfileTitleContainer>
+        사용하실 프로필을 설정해 주세요.
+      </S.SigninProfileTitleContainer>
+      <S.SigninProfileInputSection>
+        <SignInProfileImage />
+        <SignInProfileNickname />
+      </S.SigninProfileInputSection>
+    </S.SigninProfileWrapper>
+  );
+}

--- a/src/app/login/signin/_components/SignInProfile/SignInProfile.tsx
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfile.tsx
@@ -1,3 +1,4 @@
+import { SIGNIN_TEXT } from "@/constants/messages";
 import * as S from "./SignInProfile.style";
 import SignInProfileImage from "./SignInProfileImage";
 import SignInProfileNickname from "./SignInProfileNickname";
@@ -6,7 +7,7 @@ export default function SignInProfile() {
   return (
     <S.SigninProfileWrapper>
       <S.SigninProfileTitleContainer>
-        사용하실 프로필을 설정해 주세요.
+        {SIGNIN_TEXT.profileText}
       </S.SigninProfileTitleContainer>
       <S.SigninProfileInputSection>
         <SignInProfileImage />

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileImage.style.ts
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileImage.style.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const SigninProfileImageUploadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.md};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninProfileImageLabel = styled.div`
+  display: flex;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["6xs"]};
+  padding-left: ${DESIGN_SYSTEM.gap["4xs"]};
+
+  color: ${({ theme }) => theme.light["object-normal"]};
+
+  ${DESIGN_SYSTEM.typography.label.xs}
+`;
+
+export const SigninProfileImageHelperCaption = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.sm};
+  padding: ${DESIGN_SYSTEM.gap.none} ${DESIGN_SYSTEM.gap["4xs"]};
+
+  flex: 1 0 0;
+
+  color: ${({ theme }) => theme.light["object-subtle"]};
+  text-align: center;
+
+  ${DESIGN_SYSTEM.typography.body.xs}
+`;

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileImage.tsx
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileImage.tsx
@@ -6,13 +6,11 @@ export default function SignInProfileImage() {
   return (
     <S.SigninProfileImageUploadWrapper>
       <S.SigninProfileImageLabel>프로필 이미지</S.SigninProfileImageLabel>
-      <Avatar $size="2xl" badgeVisible={false} />
+      <Avatar $size="2xl" $badgeVisible={false} />
       <Button
         text="이미지 업로드"
         $size="md"
         $buttonStyle={ButtonStyle.OutlinedSecondary}
-        $isLeftIconVisible={false}
-        $isRightIconVisible={false}
       />
       <S.SigninProfileImageHelperCaption>
         jpg, png 이미지 파일을 업로드 할 수 있어요.

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileImage.tsx
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileImage.tsx
@@ -1,0 +1,22 @@
+import { Avatar, Button } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import * as S from "./SignInProfileImage.style";
+
+export default function SignInProfileImage() {
+  return (
+    <S.SigninProfileImageUploadWrapper>
+      <S.SigninProfileImageLabel>프로필 이미지</S.SigninProfileImageLabel>
+      <Avatar $size="2xl" badgeVisible={false} />
+      <Button
+        text="이미지 업로드"
+        $size="md"
+        $buttonStyle={ButtonStyle.OutlinedSecondary}
+        $isLeftIconVisible={false}
+        $isRightIconVisible={false}
+      />
+      <S.SigninProfileImageHelperCaption>
+        jpg, png 이미지 파일을 업로드 할 수 있어요.
+      </S.SigninProfileImageHelperCaption>
+    </S.SigninProfileImageUploadWrapper>
+  );
+}

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.style.ts
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.style.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+// eslint-disable-next-line import/prefer-default-export
+export const SigninProfileNicknameInputContainer = styled.div`
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.style.ts
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.style.ts
@@ -3,11 +3,22 @@
 import DESIGN_SYSTEM from "@/styles/designSystem";
 import styled from "styled-components";
 
-// eslint-disable-next-line import/prefer-default-export
 export const SigninProfileNicknameInputContainer = styled.div`
   display: flex;
   align-items: center;
   align-self: stretch;
   gap: ${DESIGN_SYSTEM.gap["2xs"]};
   padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninProfileNicknameInputLabel = styled.span`
+  color: ${({ theme }) => theme.light["object-normal"]};
+
+  ${DESIGN_SYSTEM.typography.label.xs}
+`;
+
+export const SigninProfileNicknameInputLabelStar = styled.span`
+  color: ${({ theme }) => theme.light["feedback-notification"]};
+
+  ${DESIGN_SYSTEM.typography.label.xs}
 `;

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.tsx
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.tsx
@@ -8,18 +8,24 @@ export default function SignInProfileNickname() {
       <InputField
         $size="md"
         placeholderText="김노트"
-        $iconVisible={false}
         $labelVisible
-        labelText="닉네임*"
+        label={
+          <S.SigninProfileNicknameInputLabel>
+            닉네임
+            <S.SigninProfileNicknameInputLabelStar>
+              *
+            </S.SigninProfileNicknameInputLabelStar>
+          </S.SigninProfileNicknameInputLabel>
+        }
         $helperVisible
         helperText="특수문자, 공백 제외. 한글, 영문, 숫자로 10자 이내만 가능해요."
+        countLimit="10"
+        $width="100%"
       />
       <Button
         text="중복 검사"
         $size="md"
         $buttonStyle={ButtonStyle.OutlinedPrimary}
-        $isLeftIconVisible={false}
-        $isRightIconVisible={false}
       />
     </S.SigninProfileNicknameInputContainer>
   );

--- a/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.tsx
+++ b/src/app/login/signin/_components/SignInProfile/SignInProfileNickname.tsx
@@ -1,0 +1,26 @@
+import { Button, InputField } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import * as S from "./SignInProfileNickname.style";
+
+export default function SignInProfileNickname() {
+  return (
+    <S.SigninProfileNicknameInputContainer>
+      <InputField
+        $size="md"
+        placeholderText="김노트"
+        $iconVisible={false}
+        $labelVisible
+        labelText="닉네임*"
+        $helperVisible
+        helperText="특수문자, 공백 제외. 한글, 영문, 숫자로 10자 이내만 가능해요."
+      />
+      <Button
+        text="중복 검사"
+        $size="md"
+        $buttonStyle={ButtonStyle.OutlinedPrimary}
+        $isLeftIconVisible={false}
+        $isRightIconVisible={false}
+      />
+    </S.SigninProfileNicknameInputContainer>
+  );
+}

--- a/src/app/login/signin/_components/SignInTitle/SignInTitle.style.ts
+++ b/src/app/login/signin/_components/SignInTitle/SignInTitle.style.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const SigninTitleWrapper = styled.div`
+  display: flex;
+  max-width: 30rem;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.md};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const SigninTitleText = styled.span`
+  color: ${({ theme }) => theme.light["object-hero"]};
+
+  ${DESIGN_SYSTEM.typography.title["1"]}
+`;

--- a/src/app/login/signin/_components/SignInTitle/SignInTitle.tsx
+++ b/src/app/login/signin/_components/SignInTitle/SignInTitle.tsx
@@ -1,0 +1,11 @@
+import { Logo } from "@/components";
+import * as S from "./SignInTitle.style";
+
+export default function SignInTitle() {
+  return (
+    <S.SigninTitleWrapper>
+      <Logo />
+      <S.SigninTitleText>회원가입</S.SigninTitleText>
+    </S.SigninTitleWrapper>
+  );
+}

--- a/src/app/login/signin/_components/SignInTitle/SignInTitle.tsx
+++ b/src/app/login/signin/_components/SignInTitle/SignInTitle.tsx
@@ -1,11 +1,12 @@
 import { Logo } from "@/components";
+import { SIGNIN_TEXT } from "@/constants/messages";
 import * as S from "./SignInTitle.style";
 
 export default function SignInTitle() {
   return (
     <S.SigninTitleWrapper>
       <Logo />
-      <S.SigninTitleText>회원가입</S.SigninTitleText>
+      <S.SigninTitleText>{SIGNIN_TEXT.titleText}</S.SigninTitleText>
     </S.SigninTitleWrapper>
   );
 }

--- a/src/app/login/signin/page.tsx
+++ b/src/app/login/signin/page.tsx
@@ -1,0 +1,25 @@
+import { Divider } from "@/components";
+import * as S from "./_components/SignIn.style";
+import SignInTitle from "./_components/SignInTitle/SignInTitle";
+import SignInFooter from "./_components/SignInFooter/SignInFooter";
+import SignInProfile from "./_components/SignInProfile/SignInProfile";
+import SignInJob from "./_components/SignInJob/SignInJob";
+import SignInButton from "./_components/SignInButton/SignInButton";
+
+export default function SignInPage() {
+  return (
+    <S.SigninWrapper>
+      <S.SigninModule>
+        <SignInTitle />
+        <Divider $stroke="normal" $layout="horizontal" />
+        <S.SigninBodyModule>
+          <SignInProfile />
+          <SignInJob />
+          <Divider $stroke="normal" $layout="horizontal" />
+          <SignInButton />
+        </S.SigninBodyModule>
+      </S.SigninModule>
+      <SignInFooter />
+    </S.SigninWrapper>
+  );
+}

--- a/src/constants/chips.ts
+++ b/src/constants/chips.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/prefer-default-export
+export const SIGNIN_CHIPS = [
+  "기획자",
+  "개발자",
+  "디자이너",
+  "마케터",
+  "기타 직군",
+];

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -91,3 +91,16 @@ export const DIALOG_TEXT = {
     confirmButtonText: "확인",
   },
 };
+
+export const SIGNIN_TEXT = {
+  titleText: "회원가입",
+  profileText: "사용하실 프로필을 설정해 주세요.",
+  job: {
+    titleText: "직군을 선택해 주세요.",
+    bodyText: "여러 직군을 겸하고 계신다면, 가장 가까운 직군을 골라주세요.",
+  },
+  cancelButtonText: "취소하기",
+  submitButtonText: "회원가입 완료",
+};
+
+export const STAR_ICON = "*";


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 회원가입 페이지의 UI를 1차로 완성했습니다.

## ✨ 작업 상세 설명

> `/login/signin` 페이지에서 확인하실 수 있습니다.
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/aca78be9-6b04-4791-9beb-e1224f5f0ced" />

### 🔥 문제 상황 1 `InputField` 관련

<img width="725" alt="image" src="https://github.com/user-attachments/assets/f2e143f8-e38c-4fc2-8887-91f5c1df8da2" /> 디자인 | ![image](https://github.com/user-attachments/assets/91a9c529-28fa-41c7-b9e8-2c7280469fe3) 구현 |
--- | --- |

1. `countLimit`을 지정할 수가 없습니다. `40`으로 고정되어 있습니다.
2. `labelText`를 자유롭게 할 수가 없습니다. (예시 사진의 경우, 필수를 뜻하는 `*`부분은 주황색이어야 함)
3. `border` 두께가 다릅니다..! (예시 사진의 경우 `stroke.normal`이어야 하는데 `stroke.bold`가 입력되는 것 같아요)
4. `InputField`의 prop 중 오타가 있습니다! `isNagative` → `isNegative`
5. `width`가 fix되어 있습니다ㅠㅠ 예시 사진의 경우에는 `100%`로 설정해줘야 합니다.. 

### 💦 해결 방법

- 1번과 2번의 `countLimit`와 `labelText` 관련 문제를 해결하기 위해서 `label`부분과 `caption`부분을 분리하는 것 어떻게 생각하시나요? 그 부분은 컴포넌트 사용할 때 자유롭게 조합하고 제작해서 사용할 수 있도록 하는 거죠!

```ts
export const InputField({
  // ...
  label,
  caption
}: IInputField & {
  label : React.ReactNode;
  caption : React.ReactNode;
}) {
// ...
```

- 5번의 경우 제가 [Dialog 컴포넌트 PR](https://github.com/JECT-Study/Componote-FE/pull/41)에서 문제상황 2에서 언급한 것과 마찬가지로 `style` prop을 뚫어서 개별적으로 style을 조절할 수 있도록 하면 어떨까요??

### 🔥 문제 상황 2 `Chip` 컴포넌트 관련
- Chip 컴포넌트의 prop 중 `IconComponent`는 선택 속성이어야 할 것 같습니다..!
추가로, [Button 컴포넌트에서 언급](https://github.com/JECT-Study/Componote-FE/pull/33#discussion_r1905164236)한 것처럼 `iconVisible` 속성을 없애는 것에 대해서 어떻게 생각하시나용? `IconComponent` prop이 `undefined`인지만 판단하면 될 것 같습니다!

## 🔨 추후 수정해야 하는 부분 (선택)

- [ ] InputField의 width.. (`flex: 1 0 0;` 이어야 함)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
