### PR TITLE
[✨feat]: design system page UI 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,11 @@ module.exports = {
       rules: {
         "import/no-cycle": "off",
         "import/named": "off",
-        "import/no-extraneous-dependencies": "off",
+        "import/no-extraneous-dependencies": [
+          "error",
+          { bundledDependencies: false },
+          { includeTypes: true },
+        ],
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,11 +35,7 @@ module.exports = {
       rules: {
         "import/no-cycle": "off",
         "import/named": "off",
-        "import/no-extraneous-dependencies": [
-          "error",
-          { bundledDependencies: false },
-          { includeTypes: true },
-        ],
+        "import/no-extraneous-dependencies": "off",
       },
     },
   ],

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -1,3 +1,109 @@
+"use client";
+
+import {
+  Layout,
+  NavigationBar,
+  DefaultBanner,
+  Toolbar,
+  ButtonList,
+  DesignSystemCardContainer,
+  Footer,
+  DesignSystemCard,
+  BadgeLabel,
+  Button,
+} from "@/components";
+import { BadgeLabelFeedback } from "@/components/Badge/Badge.types";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import { BANNER_TEXT } from "@/constants/messages";
+
+import githubIcon from "@/assets/icons/github-fill.svg";
+import figmaIcon from "@/assets/icons/figma-line.svg";
+import storybookIcon from "@/assets/icons/storybook-fill.svg";
+import zeroheightIcon from "@/assets/icons/zeroheight-fill.svg";
+
 export default function DesignSystem() {
-  return <div>DesignSystem</div>;
+  return (
+    <Layout>
+      <NavigationBar
+        $isAuthorized
+        $isSeparated
+        placeholderText="컴포넌트나 디자인 시스템을 검색해 보세요..."
+      />
+      <DefaultBanner
+        titleText={BANNER_TEXT.designSystem.titleText}
+        descriptionText={BANNER_TEXT.designSystem.descriptionText}
+      />
+      <Toolbar>
+        <ButtonList />
+      </Toolbar>
+      <DesignSystemCardContainer>
+        {Array.from({ length: 20 }).map((_, index) => (
+          <DesignSystemCard
+            key={`designSystemcard-${index}`}
+            designSystemName="디자인 시스템 명"
+            organizationName="회사/단체 명"
+            descriptionText="설명 내용"
+            $bookmarkCount="999+"
+            deviceLabels={
+              <>
+                <BadgeLabel
+                  $variant="labelOnly"
+                  text="데스크톱"
+                  $feedback={BadgeLabelFeedback.NONE}
+                  $style="solid"
+                  $size="xs"
+                />
+                <BadgeLabel
+                  $variant="labelOnly"
+                  text="모바일"
+                  $feedback={BadgeLabelFeedback.NONE}
+                  $style="solid"
+                  $size="xs"
+                />
+              </>
+            }
+            labels={Array.from({ length: 16 }).map((_, index) => (
+              <BadgeLabel
+                key={`label-${index}`}
+                $variant="labelOnly"
+                text="레이블"
+                $feedback={BadgeLabelFeedback.NONE}
+                $style="transparent"
+                $size="xs"
+              />
+            ))}
+            platformButtons={
+              <>
+                <Button
+                  $size="md"
+                  $buttonType="iconButton"
+                  $leftIcon={githubIcon}
+                  $buttonStyle={ButtonStyle.OutlinedSecondary}
+                />
+                <Button
+                  $size="md"
+                  $buttonType="iconButton"
+                  $leftIcon={figmaIcon}
+                  $buttonStyle={ButtonStyle.OutlinedSecondary}
+                />
+                <Button
+                  $size="md"
+                  $buttonType="iconButton"
+                  $leftIcon={storybookIcon}
+                  $buttonStyle={ButtonStyle.OutlinedSecondary}
+                />
+                <Button
+                  $size="md"
+                  $buttonType="iconButton"
+                  $leftIcon={zeroheightIcon}
+                  $buttonStyle={ButtonStyle.OutlinedSecondary}
+                />
+              </>
+            }
+          />
+        ))}
+      </DesignSystemCardContainer>
+      <Footer />
+    </Layout>
+  );
 }

--- a/src/components/Chip/Chip.group.style.ts
+++ b/src/components/Chip/Chip.group.style.ts
@@ -25,6 +25,8 @@ const ChipGroupContainer = styled.div<IChipGroupComponent>`
 
   opacity: ${DESIGN_SYSTEM.opacity.visible};
   background: ${({ theme }) => theme.light["surface-embossed"]};
+
+  z-index: 5;
 `;
 
 export default ChipGroupContainer;

--- a/src/components/Layout/Layout.style.ts
+++ b/src/components/Layout/Layout.style.ts
@@ -6,6 +6,7 @@ const LayoutContainer = styled.div`
   align-items: flex-start;
 
   width: 100vw;
+  height: 100vh;
 `;
 
 export default LayoutContainer;

--- a/src/components/Pages/DesignSystem/DesignCardContainer.style.ts
+++ b/src/components/Pages/DesignSystem/DesignCardContainer.style.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import DESIGN_SYSTEM from "@/styles/designSystem";
+
+export const CardContainer = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  align-items: stretch;
+
+  width: 100%;
+
+  background: ${({ theme }) => theme.light["surface-sunken"]};
+`;
+
+export const CardBox = styled.div`
+  display: grid;
+  justify-content: center;
+  grid-template-columns: repeat(3, 1fr);
+
+  gap: ${DESIGN_SYSTEM.gap.xl};
+  padding: ${DESIGN_SYSTEM.gap["2xl"]} ${DESIGN_SYSTEM.gap["7xl"]}
+    ${DESIGN_SYSTEM.gap["9xl"]} ${DESIGN_SYSTEM.gap["7xl"]};
+`;

--- a/src/components/Pages/DesignSystem/DesignCardContainer.tsx
+++ b/src/components/Pages/DesignSystem/DesignCardContainer.tsx
@@ -1,0 +1,15 @@
+import * as S from "./DesignCardContainer.style";
+
+interface IDesignCardContainer {
+  children: React.ReactNode;
+}
+
+export default function DesignCardContainer({
+  children,
+}: IDesignCardContainer) {
+  return (
+    <S.CardContainer>
+      <S.CardBox>{children}</S.CardBox>
+    </S.CardContainer>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,3 +34,4 @@ export { default as Dialog } from "./Dialog/Dialog";
 export { default as Layout } from "./Layout/Layout";
 export { default as CardContainer } from "./Pages/Component/CardContainer";
 export { default as ImageContainer } from "./Pages/Onboarding/ImageContainer";
+export { default as DesignSystemCardContainer } from "./Pages/DesignSystem/DesignCardContainer";


### PR DESCRIPTION
## 🚀 작업 내용

- [x] design system page UI 구현 (`/`)
  - [x] `DesignSystemCardContainer` component 구현

## ✨ 작업 상세 설명

> figma [design system page UI 플로우](https://www.figma.com/design/DYKX0B40H5ZVViUtva7HPa/%F0%9F%92%A0%EC%BB%B4%ED%8F%AC%EB%85%B8%ED%8A%B8-%EB%94%94%EC%9E%90%EC%9D%B8-%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=7052-180723&m=dev)을 기반으로 design system page UI 구현을 진행했습니다. 아래와 같습니다.

![design system](https://github.com/user-attachments/assets/c6706f8c-cdae-4353-a5c6-f55968ae048e)

### 🔥 문제 상황 (선택)

> `DesignSystemCard` component의 prop으로 버튼의 이미지를 넘겨주어야 하는데, 이를 위해 아이콘을 불러와야 합니다. 이 과정이 SSR에서 지원되지 않아 page에서 `use client`를 선언해 줘야 하는 문제가 발생하고 있습니다. 🥲 

### 💦 해결 방법 (선택)

> 추후 디자인 시스템 페이지 작업 시 button list 컴포넌트 하나를 더 생성해 거기서 이미지를 관리할 수 있도록 해 줘야 할 것 같습니다. 아직 로직은 고민 중이라 작업 진행하게 되면 반영하도록 하겠습니다!

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
