### PR TITLE
[✨feat]: Login 기본 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "componote-fe",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.64.2",
         "@types/styled-components": "^5.1.34",
         "axios": "^1.7.9",
         "next": "^15.0.3",
@@ -4045,6 +4046,32 @@
       "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.2.tgz",
+      "integrity": "sha512-hdO8SZpWXoADNTWXV9We8CwTkXU88OVWRBcsiFrk7xJQnhm6WRlweDzMD+uH+GnuieTBVSML6xFa17C2cNV8+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.64.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.2.tgz",
+      "integrity": "sha512-3pakNscZNm8KJkxmovvtZ4RaXLyiYYobwleTMvpIGUoKRa8j8VlrQKNl5W8VUEfVfZKkikvXVddLuWMbcSCA1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.64.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.64.2",
     "@types/styled-components": "^5.1.34",
     "axios": "^1.7.9",
     "next": "^15.0.3",

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = `${process.env.VITE_API_URL}/api`;
+const baseURL = `${process.env.VITE_API_URL}`;
 
 const axiosInstance = axios.create({
   baseURL,

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = `${process.env.VITE_API_URL}`;
+const baseURL = `${process.env.NEXT_PUBLIC_API_URL}`;
 
 const axiosInstance = axios.create({
   baseURL,

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,0 +1,23 @@
+import END_POINT from "@/constants/api";
+import axiosInstance from "./interceptor";
+
+export const getSocialAuthUrl = async (provider: string) => {
+  const response = await axiosInstance.get(
+    END_POINT.authorizationUrl(provider)
+  );
+  return response;
+};
+
+export const getSocialLogin = async (provider: string, code: string) => {
+  const response = await axiosInstance.get(
+    END_POINT.socialLogin(provider, code)
+  );
+  return response;
+};
+
+export const postLogin = async (socialAccountId: number) => {
+  const response = await axiosInstance.post(END_POINT.login, {
+    data: socialAccountId,
+  });
+  return response;
+};

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -8,16 +8,16 @@ export const getSocialAuthUrl = async (provider: string) => {
   return response;
 };
 
-export const getSocialLogin = async (provider: string, code: string) => {
-  const response = await axiosInstance.get(
-    END_POINT.socialLogin(provider, code)
-  );
+export const getSocialLogin = async (provider: string, code: string | null) => {
+  const response = await axiosInstance.get(END_POINT.socialLogin(provider), {
+    params: { code },
+  });
   return response;
 };
 
 export const postLogin = async (socialAccountId: number) => {
   const response = await axiosInstance.post(END_POINT.login, {
-    data: socialAccountId,
+    socialAccountId,
   });
   return response;
 };

--- a/src/app/@modal/(.)login/page.tsx
+++ b/src/app/@modal/(.)login/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { Dialog } from "@/components";
+import { useRouter } from "next/navigation";
 
 export default function LoginModal() {
+  const router = useRouter();
+
   return (
-    <Dialog>
-      <Dialog.Login />
+    <Dialog router={router}>
+      <Dialog.Login router={router} />
     </Dialog>
   );
 }

--- a/src/app/@modal/(.)login/page.tsx
+++ b/src/app/@modal/(.)login/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { Dialog } from "@/components";
+
+export default function LoginModal() {
+  return (
+    <Dialog>
+      <Dialog.Login />
+    </Dialog>
+  );
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+    return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,14 +13,16 @@ const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal
 }: Readonly<{
   children: React.ReactNode;
+  modal: React.ReactNode;
 }>) {
   return (
     <html lang="ko" className={pretendard.className}>
       <title>{metadata.title as string}</title>
       <body>
-        <ClientComponentContainer>{children}</ClientComponentContainer>
+        <ClientComponentContainer>{children}{modal}</ClientComponentContainer>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import localFont from "next/font/local";
 import ClientComponentContainer from "@/styles/ClientComponentContainer";
+import ReactQueryProviders from "@/hooks/useReactQuery";
 
 const pretendard = localFont({
   src: "./font/PretendardVariable.woff2",
@@ -13,7 +14,7 @@ const metadata: Metadata = {
 
 export default function RootLayout({
   children,
-  modal
+  modal,
 }: Readonly<{
   children: React.ReactNode;
   modal: React.ReactNode;
@@ -22,7 +23,12 @@ export default function RootLayout({
     <html lang="ko" className={pretendard.className}>
       <title>{metadata.title as string}</title>
       <body>
-        <ClientComponentContainer>{children}{modal}</ClientComponentContainer>
+        <ReactQueryProviders>
+          <ClientComponentContainer>
+            {children}
+            {modal}
+          </ClientComponentContainer>
+        </ReactQueryProviders>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,14 @@
+"use client";
+
+import { Dialog } from "@/components";
+import { useRouter } from "next/navigation";
+
 export default function Login() {
-  return <div>Login</div>;
+  const router = useRouter();
+
+  return (
+    <Dialog router={router}>
+      <Dialog.Login router={router} />
+    </Dialog>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Footer,
   NavigationBar,
@@ -5,8 +7,39 @@ import {
   OnboardingBanner,
   ImageContainer,
 } from "@/components";
+import { useLoginMutation } from "@/hooks/api/useLoginMutation";
+import { useSocialLoginQuery } from "@/hooks/api/useSocialLoginQuery";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [code, setCode] = useState<string | null>(null);
+
+  useEffect(() => {
+    // URL에서 code 파라미터 가져오기
+    const codeParam = searchParams.get("code");
+    if (codeParam) {
+      setCode(codeParam);
+    }
+  }, [searchParams]);
+
+  // TODO : 소셜 로그인 어떤 소셜인지 넣어주기! (현재 임시로 naver)
+  const { socialLoginData } = useSocialLoginQuery("naver", code);
+  const { mutate: login } = useLoginMutation();
+
+  useEffect(() => {
+    if (!code) return;
+    if (!socialLoginData) return;
+    if (!socialLoginData.isRegister) {
+      router.push("/login/signin");
+      return;
+    }
+    login({ socialAccountId: socialLoginData.socialAccountId });
+    router.push("/");
+  }, [code, socialLoginData, login, router]);
+
   return (
     <Layout>
       <NavigationBar

--- a/src/components/Dialog/Dialog.Login.tsx
+++ b/src/components/Dialog/Dialog.Login.tsx
@@ -1,11 +1,16 @@
 import { DIALOG_TEXT } from "@/constants/messages";
+import { useRouter } from "next/navigation";
 import Button from "../Button/Button";
 import { ButtonStyle } from "../Button/Button.types";
 import Divider from "../Divider/Divider";
 import SocialAuthButton from "../SocialAuth/SocialAuthButton";
 import * as S from "./Dialog.Login.style";
 
-export default function DialogLogin() {
+export default function DialogLogin({
+  router,
+}: {
+  router: ReturnType<typeof useRouter>;
+}) {
   return (
     <S.DialogLoginWrapper>
       <S.DialogLoginSection>
@@ -18,6 +23,7 @@ export default function DialogLogin() {
               text={DIALOG_TEXT.close}
               $buttonStyle={ButtonStyle.EmptySecondary}
               $size="sm"
+              onClick={() => router.back()}
             />
           </S.DialogLoginTitleContainer>
           <S.DialogLoginBodyText>

--- a/src/components/Dialog/Dialog.Login.tsx
+++ b/src/components/Dialog/Dialog.Login.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/navigation";
 import {
   useGithubAuthUrlQuery,
   useGoogleAuthUrlQuery,
+  // useNaverAuthUrlQuery,
 } from "@/hooks/api/useAuthUrlQuery";
 import Button from "../Button/Button";
 import { ButtonStyle } from "../Button/Button.types";
@@ -17,6 +18,8 @@ export default function DialogLogin({
 }) {
   const { authUrl: googleUrl } = useGoogleAuthUrlQuery();
   const { authUrl: githubUrl } = useGithubAuthUrlQuery();
+  // test를 위한 임시 코드입니다.
+  // const { authUrl: naverUrl } = useNaverAuthUrlQuery();
 
   const handleGoogleClick = () => {
     if (googleUrl) {
@@ -29,6 +32,13 @@ export default function DialogLogin({
       router.replace(githubUrl.url);
     }
   };
+
+  // test를 위한 임시 코드입니다.
+  // const handleNaverClick = () => {
+  //   if (naverUrl) {
+  //     router.replace(naverUrl.url);
+  //   }
+  // };
 
   return (
     <S.DialogLoginWrapper>
@@ -60,6 +70,12 @@ export default function DialogLogin({
             labelText={DIALOG_TEXT.login.socialGitHub}
             onClick={handleGithubClick}
           />
+          {/* 테스트를 위한 임시 코드입니다. */}
+          {/* <SocialAuthButton
+            variant="github"
+            labelText="네이버로 로그인(임시)"
+            onClick={handleNaverClick}
+          /> */}
         </S.DialogLoginButtonContainer>
       </S.DialogLoginSection>
       <Divider $layout="horizontal" $stroke="normal" />

--- a/src/components/Dialog/Dialog.Login.tsx
+++ b/src/components/Dialog/Dialog.Login.tsx
@@ -1,5 +1,9 @@
 import { DIALOG_TEXT } from "@/constants/messages";
 import { useRouter } from "next/navigation";
+import {
+  useGithubAuthUrlQuery,
+  useGoogleAuthUrlQuery,
+} from "@/hooks/api/useAuthUrlQuery";
 import Button from "../Button/Button";
 import { ButtonStyle } from "../Button/Button.types";
 import Divider from "../Divider/Divider";
@@ -11,6 +15,21 @@ export default function DialogLogin({
 }: {
   router: ReturnType<typeof useRouter>;
 }) {
+  const { authUrl: googleUrl } = useGoogleAuthUrlQuery();
+  const { authUrl: githubUrl } = useGithubAuthUrlQuery();
+
+  const handleGoogleClick = () => {
+    if (googleUrl) {
+      router.replace(googleUrl.url);
+    }
+  };
+
+  const handleGithubClick = () => {
+    if (githubUrl) {
+      router.replace(githubUrl.url);
+    }
+  };
+
   return (
     <S.DialogLoginWrapper>
       <S.DialogLoginSection>
@@ -34,10 +53,12 @@ export default function DialogLogin({
           <SocialAuthButton
             variant="google"
             labelText={DIALOG_TEXT.login.socialGoogle}
+            onClick={handleGoogleClick}
           />
           <SocialAuthButton
             variant="github"
             labelText={DIALOG_TEXT.login.socialGitHub}
+            onClick={handleGithubClick}
           />
         </S.DialogLoginButtonContainer>
       </S.DialogLoginSection>

--- a/src/components/Dialog/Dialog.Login.tsx
+++ b/src/components/Dialog/Dialog.Login.tsx
@@ -22,15 +22,11 @@ export default function DialogLogin({
   // const { authUrl: naverUrl } = useNaverAuthUrlQuery();
 
   const handleGoogleClick = () => {
-    if (googleUrl) {
-      router.replace(googleUrl.url);
-    }
+    if (googleUrl) router.replace(googleUrl.url);
   };
 
   const handleGithubClick = () => {
-    if (githubUrl) {
-      router.replace(githubUrl.url);
-    }
+    if (githubUrl) router.replace(githubUrl.url);
   };
 
   // test를 위한 임시 코드입니다.

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/navigation";
 import DialogBasic from "./Dialog.Basic";
 import DialogComplete from "./Dialog.Complete";
 import DialogEmailVerification from "./Dialog.EmailVerification";
@@ -6,10 +7,25 @@ import DialogReport from "./Dialog.Report";
 import DialogVerification from "./Dialog.Verification";
 import * as S from "./Dialog.style";
 
-export default function Dialog({ children }: { children: React.ReactNode }) {
+export default function Dialog({
+  children,
+  router,
+}: {
+  children: React.ReactNode;
+  router: ReturnType<typeof useRouter>;
+}) {
+  const handleDimmedClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    router.back();
+  };
+
+  const handleDialogClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+  };
+
   return (
-    <S.DimmedScreen>
-      <S.DialogWrapper>{children}</S.DialogWrapper>
+    <S.DimmedScreen onClick={handleDimmedClick}>
+      <S.DialogWrapper onClick={handleDialogClick}>{children}</S.DialogWrapper>
     </S.DimmedScreen>
   );
 }

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -2,6 +2,7 @@ import { Logo, Button, NavItem, Avatar, InputField } from "@/components";
 import sunIcon from "@/assets/icons/sun-line.svg";
 import searchIcon from "@/assets/icons/search-line.svg";
 import { NAVBAR_ITEM_TEXT } from "@/constants/messages";
+import { useRouter } from "next/navigation";
 import * as S from "./NavigationBar.style";
 import { ButtonStyle } from "../Button/Button.types";
 import { IInputField, INavigation } from "./NavigationBar.types";
@@ -11,6 +12,8 @@ export default function NavigationBar({
   $isSeparated,
   $isAuthorized,
 }: INavigation & IInputField) {
+  const router = useRouter();
+
   return (
     <S.NavigationBarContainer
       $isAuthorized={$isAuthorized}
@@ -49,6 +52,7 @@ export default function NavigationBar({
                 $size="sm"
                 $buttonType="button"
                 $buttonStyle={ButtonStyle.SolidPrimary}
+                onClick={() => router.push("/login")}
               />
             </S.NavItemBox>
           )}

--- a/src/components/SocialAuth/SocialAuthButton.tsx
+++ b/src/components/SocialAuth/SocialAuthButton.tsx
@@ -6,14 +6,16 @@ import { SocialAuthIcGithub, SocialAuthIcGoogle } from "./SocialAuthIcon.style";
 interface ISocialAuthButton {
   variant: "google" | "github";
   labelText: string;
+  onClick?: () => void;
 }
 
 export default function SocialAuthButton({
   variant,
   labelText,
+  onClick,
 }: ISocialAuthButton) {
   return (
-    <S.SocialAuthBtn>
+    <S.SocialAuthBtn onClick={onClick}>
       {variant === "google" ? <SocialAuthIcGoogle /> : <SocialAuthIcGithub />}
       <S.SocialAuthLabelText>{labelText}</S.SocialAuthLabelText>
       <InteractionContainer

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -9,8 +9,7 @@ const END_POINT = {
   modifyEmail: "/members/email",
   authorizationUrl: (providerType: string) =>
     `/oauth/${providerType}/authorization-url`,
-  socialLogin: (providerType: string, code: string) =>
-    `/oauth/${providerType}/login?code=${code}`,
+  socialLogin: (providerType: string) => `/oauth/${providerType}/login`,
 
   /* comment end point */
   createComment: "/comments",
@@ -23,7 +22,7 @@ const END_POINT = {
     componentId: number,
     page: number,
     size: number,
-    sort: string,
+    sort: string
   ) =>
     `components/${componentId}/comments?page=${page}&size=${size}&sort=${sort}`,
   like: (commentId: number) => `/comment-likes/${commentId}`, // POST, DELETE
@@ -35,7 +34,7 @@ const END_POINT = {
     types: string,
     page: number,
     size: number,
-    sort: string,
+    sort: string
   ) =>
     `/components/search?keyword=${keyword}&types=${types}&page=${page}&size=${size}&sort=${sort}`,
 

--- a/src/hooks/api/useAuthUrlQuery.ts
+++ b/src/hooks/api/useAuthUrlQuery.ts
@@ -1,0 +1,37 @@
+import { getSocialAuthUrl } from "@/api/login";
+import { IAuthCode } from "@/types/login";
+import { useQuery } from "@tanstack/react-query";
+
+export function useGoogleAuthUrlQuery() {
+  const { data: authUrl } = useQuery<IAuthCode>({
+    queryKey: ["authUrl", "google"],
+    queryFn: async () => {
+      const response = await getSocialAuthUrl("google");
+      return response.data;
+    },
+  });
+  return { authUrl };
+}
+
+export function useGithubAuthUrlQuery() {
+  const { data: authUrl } = useQuery<IAuthCode>({
+    queryKey: ["authUrl", "github"],
+    queryFn: async () => {
+      const response = await getSocialAuthUrl("github");
+      return response.data;
+    },
+  });
+  return { authUrl };
+}
+
+// test를 위한 임시 코드입니다 (추후 Naver 로그인도 추가할 수 있음)
+export function useNaverAuthUrlQuery() {
+  const { data: authUrl } = useQuery<IAuthCode>({
+    queryKey: ["authUrl", "naver"],
+    queryFn: async () => {
+      const response = await getSocialAuthUrl("naver");
+      return response.data;
+    },
+  });
+  return { authUrl };
+}

--- a/src/hooks/api/useLoginMutation.ts
+++ b/src/hooks/api/useLoginMutation.ts
@@ -1,0 +1,12 @@
+import { postLogin } from "@/api/login";
+import { useMutation } from "@tanstack/react-query";
+
+// eslint-disable-next-line import/prefer-default-export
+export function useLoginMutation() {
+  return useMutation({
+    mutationFn: async ({ socialAccountId }: { socialAccountId: number }) => {
+      const response = await postLogin(socialAccountId);
+      return response.data;
+    },
+  });
+}

--- a/src/hooks/api/useSocialLoginQuery.ts
+++ b/src/hooks/api/useSocialLoginQuery.ts
@@ -1,0 +1,17 @@
+import { getSocialLogin } from "@/api/login";
+import { ISocialLogin } from "@/types/login";
+import { useQuery } from "@tanstack/react-query";
+
+// eslint-disable-next-line import/prefer-default-export
+export function useSocialLoginQuery(provider: string, code: string | null) {
+  const { data: socialLoginData } = useQuery<ISocialLogin>({
+    queryKey: ["socialLogin", provider, code],
+    queryFn: async () => {
+      const response = await getSocialLogin(provider, code);
+      return response.data;
+    },
+    enabled: !!code, // code가 존재할 때만 실행
+  });
+
+  return { socialLoginData };
+}

--- a/src/hooks/useReactQuery.tsx
+++ b/src/hooks/useReactQuery.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export default function ReactQueryProviders({
+  children,
+}: React.PropsWithChildren) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,0 +1,13 @@
+export interface IAuthCode {
+  url: string;
+}
+
+export interface ISocialLogin {
+  isRegister: false;
+  socialAccountId: number;
+}
+
+export interface ILogin {
+  accessToken: string;
+  memberId: number;
+}


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 소셜 로그인 기능을 구현했습니다.
- [x] 환경변수 오류 수정 (`NEXT_PUBLIC_`)
- [x] `tanstack/react-query` 설치

## ✨ 작업 상세 설명

- 랜딩 페이지에서 로그인 버튼을 누르면 Modal이 뜹니다
![image](https://github.com/user-attachments/assets/11808a37-e123-4ed3-a679-77437c7b0161)
- 여기서 버튼을 누르면 각 소셜 로그인 Authorize 페이지로 이동
![image](https://github.com/user-attachments/assets/1a4923bd-6844-49b5-92c1-e885fa4e3fa0)
- 이후 랜딩페이지로 redirect 되면서 `code`가 함께 옴
- URL의 `param`으로 온 `code`를 추출하여 (`useSearchParams()` 활용) 소셜로그인 요청
- 소셜로그인 GET 요청을 통해 받은 `isRegister`에 따라서 `login` 로직을 실행시키거나 `signin`페이지로 이동시킴


### 🔥 문제 상황 1 어떤 소셜 로그인인지 전달 불가
![image](https://github.com/user-attachments/assets/93eb17cf-783c-4f12-8089-2783f00d6a8f)

### 💦 해결 방법 1
추후 상태관리 라이브러리 도입을 통해 해결 예정

## 🔨 추후 수정해야 하는 부분 (선택)

- [ ] 어떤 소셜로그인인지 상태에 저장해두고 쓸 수 있도록 하기
- [ ] 로그인 후 `access token` 저장 (이것도 상태관리 라이브러리 통해서 구현 예정)
- [ ] 현재 랜딩페이지의 page.tsx에 로그인 관련 로직이 담겨있음 => 이부분 리팩토링 해야할 것으로 보임 
  - 근데 어떻게 해야되는지 모르겠어서 못함.. `"use client"`없애고 싶은데 커스텀 훅으로 빼도 `"use client"`는 있어야해서... 고민...🤔

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
