### PR TITLE
[♻️refactor]: Toolbar에 ContextMenu 적용하기

### DIFF
--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -23,7 +23,10 @@ export default function Component() {
         titleText={BANNER_TEXT.component.titleText}
         descriptionText={BANNER_TEXT.component.descriptionText}
       />
-      <Toolbar contextMenuItemLabels={COMPONENT_CONTEXT_MENU_ITEM_LABELS}>
+      <Toolbar
+        contextMenuItemLabels={COMPONENT_CONTEXT_MENU_ITEM_LABELS}
+        defaultItem={COMPONENT_CONTEXT_MENU_ITEM_LABELS[0]}
+      >
         <ChipList />
       </Toolbar>
       <CardContainer>

--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -8,6 +8,7 @@ import {
   CardContainer,
   Footer,
 } from "@/components";
+import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 import { BANNER_TEXT } from "@/constants/messages";
 
 export default function Component() {
@@ -22,7 +23,7 @@ export default function Component() {
         titleText={BANNER_TEXT.component.titleText}
         descriptionText={BANNER_TEXT.component.descriptionText}
       />
-      <Toolbar>
+      <Toolbar contextMenuItemLabels={COMPONENT_CONTEXT_MENU_ITEM_LABELS}>
         <ChipList />
       </Toolbar>
       <CardContainer>

--- a/src/components/ContextMenu/ContextMenu.style.ts
+++ b/src/components/ContextMenu/ContextMenu.style.ts
@@ -2,6 +2,11 @@ import DESIGN_SYSTEM from "@/styles/designSystem";
 import styled from "styled-components";
 
 export const ContextMenu = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 5px);
+
   width: 11.875rem;
   max-height: 21rem;
 
@@ -22,6 +27,8 @@ export const ContextMenu = styled.div`
   ::-webkit-scrollbar {
     display: none;
   }
+
+  z-index: 100;
 `;
 
 export const ItemContainer = styled.div`

--- a/src/components/ContextMenu/ContextMenu.style.ts
+++ b/src/components/ContextMenu/ContextMenu.style.ts
@@ -1,13 +1,14 @@
 import DESIGN_SYSTEM from "@/styles/designSystem";
 import styled from "styled-components";
+import { IContextMenuStyle } from "./ContextMenu.types";
 
-export const ContextMenu = styled.div`
+export const ContextMenu = styled.div<IContextMenuStyle>`
   position: absolute;
   top: 100%;
   left: 50%;
   transform: translate(-50%, 5px);
 
-  width: 11.875rem;
+  width: ${({ $width }) => $width || "11.875rem"};
   max-height: 21rem;
 
   display: flex;

--- a/src/components/ContextMenu/ContextMenu.theme.ts
+++ b/src/components/ContextMenu/ContextMenu.theme.ts
@@ -5,10 +5,14 @@ import { BadgeLabelFeedback } from "../Badge/Badge.types";
 
 export const CONTEXT_MENU_ITEM_SIZE = {
   sm: {
+    paddingY: DESIGN_SYSTEM.gap["3xs"],
+    paddingX: DESIGN_SYSTEM.gap.xs,
     itemLabelText: DESIGN_SYSTEM.typography.label.xs,
     iconSize: DESIGN_SYSTEM.iconSize.xs,
   },
   md: {
+    paddingY: DESIGN_SYSTEM.gap.xs,
+    paddingX: DESIGN_SYSTEM.gap.md,
     itemLabelText: DESIGN_SYSTEM.typography.label.md,
     iconSize: DESIGN_SYSTEM.iconSize.md,
   },

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import * as S from "./ContextMenu.style";
 import ContextMenuItem from "./ContextMenuItem";
-import { IContextMenu } from "./ContextMenu.types";
+import { IContextMenu, IContextMenuStyle } from "./ContextMenu.types";
 
-export default function ContextMenu({ children }: IContextMenu) {
+export default function ContextMenu({
+  children,
+  $width,
+}: IContextMenu & IContextMenuStyle) {
   return (
-    <S.ContextMenu>
+    <S.ContextMenu $width={$width}>
       <S.ItemContainer>{children}</S.ItemContainer>
     </S.ContextMenu>
   );

--- a/src/components/ContextMenu/ContextMenu.types.ts
+++ b/src/components/ContextMenu/ContextMenu.types.ts
@@ -15,6 +15,7 @@ export interface IContextMenuItem extends IContextMenuItemStyle {
   subLabelText?: string;
   captionText?: string;
   badgeLabelText?: string;
+  onClick?: () => void;
 }
 
 export interface IContextMenu {

--- a/src/components/ContextMenu/ContextMenu.types.ts
+++ b/src/components/ContextMenu/ContextMenu.types.ts
@@ -10,6 +10,7 @@ export interface IContextMenuItemStyle {
 }
 
 export interface IContextMenuItem extends IContextMenuItemStyle {
+  icon?: React.ElementType;
   labelText: string;
   subLabelText?: string;
   captionText?: string;

--- a/src/components/ContextMenu/ContextMenu.types.ts
+++ b/src/components/ContextMenu/ContextMenu.types.ts
@@ -18,6 +18,10 @@ export interface IContextMenuItem extends IContextMenuItemStyle {
   onClick?: () => void;
 }
 
+export interface IContextMenuStyle {
+  $width?: string;
+}
+
 export interface IContextMenu {
   children: React.ReactNode;
 }

--- a/src/components/ContextMenu/ContextMenuItem.style.ts
+++ b/src/components/ContextMenu/ContextMenuItem.style.ts
@@ -1,7 +1,7 @@
 import DESIGN_SYSTEM from "@/styles/designSystem";
 import styled from "styled-components";
 import checkboxBlankLine from "@/assets/icons/checkbox-blank-line.svg";
-import blankLine from "@/assets/icons/blank-line.svg";
+import { IconWrapper } from "@/utils/IconWrapper";
 import {
   CONTEXT_MENU_ITEM_FEEDBACK_COLOR,
   CONTEXT_MENU_ITEM_SIZE,
@@ -17,7 +17,8 @@ export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
   display: inline-flex;
   align-items: center;
   gap: ${DESIGN_SYSTEM.gap["2xs"]};
-  padding: ${DESIGN_SYSTEM.gap.xs} ${DESIGN_SYSTEM.gap.md};
+  padding: ${({ $size }) =>
+    `${CONTEXT_MENU_ITEM_SIZE[$size].paddingY} ${CONTEXT_MENU_ITEM_SIZE[$size].paddingX}`};
 
   border-radius: ${DESIGN_SYSTEM.radius.xs};
   opacity: ${DESIGN_SYSTEM.opacity.visible};
@@ -34,7 +35,7 @@ export const ContextMenuCheckboxIcon = styled(
   }
 `;
 
-export const ContextMenuBlankLine = styled(blankLine)<IContextMenuItemStyle>`
+export const ContextMenuIcon = styled(IconWrapper)<IContextMenuItemStyle>`
   width: ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].iconSize};
   height: ${({ $size }) => CONTEXT_MENU_ITEM_SIZE[$size].iconSize};
 

--- a/src/components/ContextMenu/ContextMenuItem.style.ts
+++ b/src/components/ContextMenu/ContextMenuItem.style.ts
@@ -8,7 +8,7 @@ import {
 } from "./ContextMenu.theme";
 import { IContextMenuItemStyle } from "./ContextMenu.types";
 
-export const ContextMenuItem = styled.div<IContextMenuItemStyle>`
+export const ContextMenuItem = styled.button<IContextMenuItemStyle>`
   position: relative;
 
   width: 100%;

--- a/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/src/components/ContextMenu/ContextMenuItem.tsx
@@ -9,6 +9,7 @@ export default function ContextMenuItem({
   $variant,
   $size,
   $feedback = "normal",
+  icon,
   labelText,
   subLabelText,
   captionText,
@@ -19,8 +20,12 @@ export default function ContextMenuItem({
       {$variant === "checkbox" && (
         <S.ContextMenuCheckboxIcon $variant={$variant} $size={$size} />
       )}
-      {$variant === "leftIcon" && (
-        <S.ContextMenuBlankLine $variant={$variant} $size={$size} />
+      {$variant === "leftIcon" && icon && (
+        <S.ContextMenuIcon
+          IconComponent={icon}
+          $variant={$variant}
+          $size={$size}
+        />
       )}
       <S.ContextMenuItemSection>
         {$variant === "badge" ? (
@@ -69,8 +74,12 @@ export default function ContextMenuItem({
           </S.ContextMenuItemCaptionText>
         )}
       </S.ContextMenuItemSection>
-      {$variant === "rightIcon" && (
-        <S.ContextMenuBlankLine $variant={$variant} $size={$size} />
+      {$variant === "rightIcon" && icon && (
+        <S.ContextMenuIcon
+          IconComponent={icon}
+          $variant={$variant}
+          $size={$size}
+        />
       )}
       <InteractionContainer
         $variant={CONTEXT_MENU_ITEM_FEEDBACK_COLOR[$feedback].interaction}

--- a/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/src/components/ContextMenu/ContextMenuItem.tsx
@@ -14,9 +14,15 @@ export default function ContextMenuItem({
   subLabelText,
   captionText,
   badgeLabelText,
+  onClick,
 }: IContextMenuItem) {
   return (
-    <S.ContextMenuItem $variant={$variant} $size={$size}>
+    <S.ContextMenuItem
+      type="button"
+      $variant={$variant}
+      $size={$size}
+      onClick={onClick}
+    >
       {$variant === "checkbox" && (
         <S.ContextMenuCheckboxIcon $variant={$variant} $size={$size} />
       )}

--- a/src/components/Toolbar/Toolbar.style.ts
+++ b/src/components/Toolbar/Toolbar.style.ts
@@ -72,6 +72,8 @@ export const FilterIcon = styled(filterIcon)`
 `;
 
 export const ButtonBox = styled.div`
+  position: relative;
+
   display: flex;
   justify-content: flex-end;
   align-items: center;

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -30,6 +30,11 @@ export default function Toolbar({
     return selectedTabIndex === 0 ? <ChipList /> : <ButtonList />;
   };
 
+  const handleContextMenuSelect = (label: string) => {
+    setSelectedItem(label);
+    setIsContextMenuOpen(false);
+  };
+
   return (
     <S.ToolbarContainer>
       {!children && (
@@ -75,7 +80,7 @@ export default function Toolbar({
                   $variant={selectedItem === label ? "rightIcon" : "labelOnly"}
                   icon={selectedItem === label ? checkLineIcon : null}
                   $size="sm"
-                  onClick={() => setSelectedItem(label)}
+                  onClick={() => handleContextMenuSelect(label)}
                 />
               ))}
             </ContextMenu>

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -9,12 +9,17 @@ import { ButtonStyle } from "../Button/Button.types";
 interface IToolbar {
   children?: React.ReactNode;
   contextMenuItemLabels?: string[];
+  defaultItem?: string;
 }
 
-export default function Toolbar({ children, contextMenuItemLabels }: IToolbar) {
+export default function Toolbar({
+  children,
+  contextMenuItemLabels,
+  defaultItem,
+}: IToolbar) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
-  const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
-  const [selectedItem, setSelectedItem] = useState("");
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState<boolean>(false);
+  const [selectedItem, setSelectedItem] = useState<string>(defaultItem || "");
 
   const handleTabSelect = (index: number) => {
     setSelectedTabIndex(index);
@@ -54,7 +59,7 @@ export default function Toolbar({ children, contextMenuItemLabels }: IToolbar) {
         </S.ToolBox>
         <S.ButtonBox>
           <Button
-            text="이름 순으로 정렬"
+            text={selectedItem}
             $size="xs"
             $buttonType="button"
             $rightIcon={arrowDown}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -14,6 +14,7 @@ interface IToolbar {
 export default function Toolbar({ children, contextMenuItemLabels }: IToolbar) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+  const [selectedItem, setSelectedItem] = useState("");
 
   const handleTabSelect = (index: number) => {
     setSelectedTabIndex(index);
@@ -66,9 +67,10 @@ export default function Toolbar({ children, contextMenuItemLabels }: IToolbar) {
                 <ContextMenu.Item
                   key={label}
                   labelText={label}
-                  $variant="rightIcon"
-                  icon={checkLineIcon}
+                  $variant={selectedItem === label ? "rightIcon" : "labelOnly"}
+                  icon={selectedItem === label ? checkLineIcon : null}
                   $size="sm"
+                  onClick={() => setSelectedItem(label)}
                 />
               ))}
             </ContextMenu>

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -62,7 +62,7 @@ export default function Toolbar({ children, contextMenuItemLabels }: IToolbar) {
             onClick={() => setIsContextMenuOpen(!isContextMenuOpen)}
           />
           {isContextMenuOpen && (
-            <ContextMenu>
+            <ContextMenu $width="160px">
               {contextMenuItemLabels?.map((label) => (
                 <ContextMenu.Item
                   key={label}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react";
-import { Button, ButtonList, ChipList, Tab } from "@/components";
+import { Button, ButtonList, ChipList, ContextMenu, Tab } from "@/components";
 import resetIcon from "@/assets/icons/reset-left-line.svg";
 import arrowDown from "@/assets/icons/arrow-down.svg";
+import checkLineIcon from "@/assets/icons/check-line.svg";
 import * as S from "./Toolbar.style";
 import { ButtonStyle } from "../Button/Button.types";
 
 interface IToolbar {
   children?: React.ReactNode;
+  contextMenuItemLabels?: string[];
 }
 
-export default function Toolbar({ children }: IToolbar) {
+export default function Toolbar({ children, contextMenuItemLabels }: IToolbar) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
 
   const handleTabSelect = (index: number) => {
     setSelectedTabIndex(index);
@@ -55,7 +58,21 @@ export default function Toolbar({ children }: IToolbar) {
             $buttonType="button"
             $rightIcon={arrowDown}
             $buttonStyle={ButtonStyle.OutlinedSecondary}
+            onClick={() => setIsContextMenuOpen(!isContextMenuOpen)}
           />
+          {isContextMenuOpen && (
+            <ContextMenu>
+              {contextMenuItemLabels?.map((label) => (
+                <ContextMenu.Item
+                  key={label}
+                  labelText={label}
+                  $variant="rightIcon"
+                  icon={checkLineIcon}
+                  $size="sm"
+                />
+              ))}
+            </ContextMenu>
+          )}
         </S.ButtonBox>
       </S.ToolContainer>
     </S.ToolbarContainer>

--- a/src/constants/contextMenuLabels.ts
+++ b/src/constants/contextMenuLabels.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/prefer-default-export
+export const COMPONENT_CONTEXT_MENU_ITEM_LABELS = [
+  "이름 순으로 정렬",
+  "조회 순으로 정렬",
+  "댓글 순으로 정렬",
+];


### PR DESCRIPTION
## 🚀 작업 내용

- [ ] Toolbar에 우측 Button을 눌렀을 때, ContextMenu가 뜨도록 구현함

## ✨ 작업 상세 설명

- Toolbar 컴포넌트에 `useState`를 통해 `ContextMenu`가 열렸는지, 닫혔는지를 관리 => 열린 경우에만 ContextMenu가 보여지도록 함
- Toolbar가 사용되는 페이지에서 `ContextMenuItem`에 들어갈 `string` 배열을 전달해줘야 함 (예시로는 [`src/app/component/page.tsx`](https://github.com/JECT-Study/Componote-FE/pull/55/files#diff-64bf80da23535807f010b27f2b317f06c50c6c691a0c04fd530d4e0336888b5f) 파일 확인)

### 🔥 문제 상황 (선택)
- `ContextMenuItem`의 `width`가 이상함
![image](https://github.com/user-attachments/assets/d00b5d17-c2f9-40be-b3fa-b08a751787b7)

### 💦 해결 방법 (선택)

- ContextMenu에 width 프롭을 추가함
- figma에 적혀있는 `158px` 대신 `160px`로 설정함 (아래 사진은 158px로 설정했을 경우)
![image](https://github.com/user-attachments/assets/00ed8e56-1576-4b7a-bea4-78d1456339de)
- DevMode 사용 불가로 px값으로 설정함
![image](https://github.com/user-attachments/assets/8e187e1e-e319-4752-810e-d9047e0ca86f)


## 🔨 추후 수정해야 하는 부분 (선택)

- [ ] 현재는 `ButtonBox`를 눌렀을 때만 열리고 닫힘 => 추후에는 `ContextMenu` 바깥쪽을 눌렀을 때도 `ContextMenu`가 닫히도록 수정해야 함 (오래 걸릴 것 같아서 일단은.. 보류)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
