### PR TITLE
[✨feat]: component page component list 구현

### DIFF
--- a/src/api/component.ts
+++ b/src/api/component.ts
@@ -1,0 +1,17 @@
+import END_POINT from "@/constants/api";
+import axiosInstance from "./interceptor";
+
+// eslint-disable-next-line import/prefer-default-export
+export const searchComponent = async (
+  page: number,
+  size: number,
+  keyword?: string,
+  types?: string,
+  sort?: string,
+) => {
+  const { data } = await axiosInstance.get(
+    `${END_POINT.searchComponent(page, size, keyword, types, sort)}`,
+  );
+
+  return data;
+};

--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -11,7 +11,11 @@ import {
   Footer,
   EmptyState,
 } from "@/components";
-import { BANNER_TEXT, NAVBAR_ITEM_TEXT } from "@/constants/messages";
+import {
+  BANNER_TEXT,
+  COMPONENT_PAGE_TEXT,
+  NAVBAR_ITEM_TEXT,
+} from "@/constants/messages";
 import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useObserver } from "@/hooks/api/common/useObserver";
@@ -66,8 +70,8 @@ export default function Component() {
           )),
         )}
       </CardContainer>
-      {isLoading && <EmptyState text="컴포넌트 목록을 로드 중이에요" />}
-      {isError && <EmptyState text="컴포넌트 목록을 로드할 수 없어요" />}
+      {isLoading && <EmptyState text={COMPONENT_PAGE_TEXT.loading} />}
+      {isError && <EmptyState text={COMPONENT_PAGE_TEXT.error} />}
       <div ref={lastElementRef} />
       <Footer />
     </Layout>

--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -20,14 +20,14 @@ import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useObserver } from "@/hooks/api/common/useObserver";
 import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
-import { useComponentList } from "@/hooks/api/component/useComponentList";
+import { useComponentListInfiniteQuery } from "@/hooks/api/component/useComponentListInfiniteQuery";
 import { IComponentData } from "@/types/component";
 
 export default function Component() {
   const router = useRouter();
   const lastElementRef = useRef<HTMLDivElement | null>(null);
   const { data, fetchNextPage, hasNextPage, isLoading, isError } =
-    useComponentList();
+    useComponentListInfiniteQuery();
 
   useObserver({
     target: lastElementRef,

--- a/src/components/Badge/Badge.ComponentType.tsx
+++ b/src/components/Badge/Badge.ComponentType.tsx
@@ -11,6 +11,7 @@ export default function BadgeComponentType({
   $size,
 }: IBadgeComponentType) {
   const text = BADGE_COMPONENT_TYPE_TEXT[$type];
+
   return (
     <BadgeComponentTypeContainer $type={$type} $style={$style} $size={$size}>
       {text}

--- a/src/components/Badge/Badge.theme.ts
+++ b/src/components/Badge/Badge.theme.ts
@@ -95,10 +95,10 @@ export const BADGE_LABEL_SIZE = {
 };
 
 export const BADGE_COMPONENT_TYPE_COLOR = {
-  input: "cyan",
-  display: "violet",
-  feedback: "rose",
-  navigation: "lime",
+  INPUT: "cyan",
+  DISPLAY: "violet",
+  FEEDBACK: "rose",
+  NAVIGATION: "lime",
 };
 
 export const BADGE_COMPONENT_TYPE_SIZE = {

--- a/src/components/Card/Card.component.tsx
+++ b/src/components/Card/Card.component.tsx
@@ -11,6 +11,8 @@ import { DimmedScreen, DisabledInteraction } from "./CardInteraction";
 
 export default function ComponentCard({
   $src,
+  onClick,
+  $type,
   $isDisabled,
   componentName,
   descriptionText,
@@ -19,10 +21,10 @@ export default function ComponentCard({
   $bookmarkCount,
 }: IComponentCard & ICardComponent) {
   return (
-    <S.CardContainer $isDisabled={$isDisabled}>
+    <S.CardContainer onClick={onClick} $isDisabled={$isDisabled}>
       <S.ImageBox>
         <S.CardImage $src={$src} />
-        <BadgeComponentType $size="xs" $type="input" $style="solid" />
+        <BadgeComponentType $size="xs" $type={$type} $style="solid" />
         {$isDisabled && <DimmedScreen />}
       </S.ImageBox>
       <S.DescriptionBox>

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -5,11 +5,13 @@ export interface ICardComponent {
 
 /* component card에 사용되는 props type입니다. */
 export interface IComponentCard {
+  $type: "input" | "display" | "feedback" | "navigation";
   componentName: string;
   descriptionText: string;
   $sampleCount: string;
   $commentCount: string;
   $bookmarkCount: string;
+  onClick: () => void;
 }
 
 /* card item component에 사용되는 props type입니다. */

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -5,7 +5,7 @@ export interface ICardComponent {
 
 /* component card에 사용되는 props type입니다. */
 export interface IComponentCard {
-  $type: "input" | "display" | "feedback" | "navigation";
+  $type: "INPUT" | "DISPLAY" | "FEEDBACK" | "NAVIGATION";
   componentName: string;
   descriptionText: string;
   $sampleCount: string;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -22,7 +22,7 @@ const END_POINT = {
     componentId: number,
     page: number,
     size: number,
-    sort: string
+    sort: string,
   ) =>
     `components/${componentId}/comments?page=${page}&size=${size}&sort=${sort}`,
   like: (commentId: number) => `/comment-likes/${commentId}`, // POST, DELETE
@@ -30,11 +30,11 @@ const END_POINT = {
   /* component end point */
   componentDetail: (componentId: number) => `/components/${componentId}`,
   searchComponent: (
-    keyword: string,
-    types: string,
-    page: number,
-    size: number,
-    sort: string
+    page: number = 0,
+    size: number = 10,
+    keyword: string = "",
+    types: string = "",
+    sort: string = "viewCount,desc",
   ) =>
     `/components/search?keyword=${keyword}&types=${types}&page=${page}&size=${size}&sort=${sort}`,
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -34,7 +34,7 @@ const END_POINT = {
     size: number = 10,
     keyword: string = "",
     types: string = "",
-    sort: string = "viewCount,desc",
+    sort: string = "asc",
   ) =>
     `/components/search?keyword=${keyword}&types=${types}&page=${page}&size=${size}&sort=${sort}`,
 

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -128,3 +128,8 @@ export const COMPONENT_DETAIL_PAGE_TEXT = {
     buttonLabel: "보러 가기",
   },
 };
+
+export const COMPONENT_PAGE_TEXT = {
+  loading: "컴포넌트 목록을 로드 중이에요",
+  error: "컴포넌트 목록을 로드할 수 없어요",
+};

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -5,10 +5,10 @@ export const FOOTER_TEXT = {
 };
 
 export const BADGE_COMPONENT_TYPE_TEXT = {
-  input: "Input 입력",
-  display: "Display 표시",
-  feedback: "Feedback 반응",
-  navigation: "Navigation 안내",
+  INPUT: "Input 입력",
+  DISPLAY: "Display 표시",
+  FEEDBACK: "Feedback 반응",
+  NAVIGATION: "Navigation 안내",
 };
 
 export const NAVBAR_ITEM_TEXT = {

--- a/src/hooks/api/common/useObserver.ts
+++ b/src/hooks/api/common/useObserver.ts
@@ -1,0 +1,34 @@
+import { useEffect, RefObject } from "react";
+
+interface UseObserverProps {
+  target: RefObject<HTMLElement>;
+  onIntersect: IntersectionObserverCallback;
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const useObserver = ({
+  target,
+  onIntersect,
+  root = null,
+  rootMargin = "0px",
+  threshold = 1.0,
+}: UseObserverProps) => {
+  useEffect(() => {
+    let observer: IntersectionObserver;
+
+    if (target && target.current) {
+      observer = new IntersectionObserver(onIntersect, {
+        root,
+        rootMargin,
+        threshold,
+      });
+
+      observer.observe(target.current);
+    }
+
+    return () => observer && observer.disconnect();
+  }, [target, onIntersect, root, rootMargin, threshold]);
+};

--- a/src/hooks/api/component/useComponentList.ts
+++ b/src/hooks/api/component/useComponentList.ts
@@ -1,0 +1,27 @@
+import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+import { searchComponent } from "@/api/component";
+import { IPageData } from "@/types/component";
+
+interface IPageParam {
+  pageParam: number | unknown;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const useComponentList = () => {
+  const fetchComponents = async ({
+    pageParam,
+  }: IPageParam): Promise<IPageData> => {
+    const page = typeof pageParam === "number" ? pageParam : 0;
+    const data = await searchComponent(page, 10);
+
+    return data;
+  };
+
+  return useInfiniteQuery<IPageData, Error, InfiniteData<IPageData>>({
+    queryKey: ["components"],
+    queryFn: fetchComponents,
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,
+  });
+};

--- a/src/hooks/api/component/useComponentListInfiniteQuery.ts
+++ b/src/hooks/api/component/useComponentListInfiniteQuery.ts
@@ -7,7 +7,7 @@ interface IPageParam {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export const useComponentList = () => {
+export const useComponentListInfiniteQuery = () => {
   const fetchComponents = async ({
     pageParam,
   }: IPageParam): Promise<IPageData> => {

--- a/src/stories/Badge/Badge.ComponentType.stories.tsx
+++ b/src/stories/Badge/Badge.ComponentType.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   },
   argTypes: {
     $type: {
-      options: ["input", "display", "feedback", "navigation"],
+      options: ["INPUT", "DISPLAY", "FEEDBACK", "NAVIGATION"],
       control: { type: "radio" },
     },
     $style: {
@@ -31,7 +31,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    $type: "input",
+    $type: "INPUT",
     $style: "solid",
     $size: "md",
   },
@@ -47,7 +47,7 @@ export const InputTransparent: Story = {
 export const DisplaySolid: Story = {
   args: {
     ...Default.args,
-    $type: "display",
+    $type: "DISPLAY",
   },
 };
 
@@ -61,7 +61,7 @@ export const DisplayTransparent: Story = {
 export const FeedbackSolid: Story = {
   args: {
     ...Default.args,
-    $type: "feedback",
+    $type: "FEEDBACK",
   },
 };
 
@@ -75,7 +75,7 @@ export const FeedbackTransparent: Story = {
 export const NavigationSolid: Story = {
   args: {
     ...Default.args,
-    $type: "navigation",
+    $type: "NAVIGATION",
   },
 };
 

--- a/src/stories/Card/Card.component.stories.tsx
+++ b/src/stories/Card/Card.component.stories.tsx
@@ -51,7 +51,7 @@ function CardContainer(StoryFn: () => JSX.Element) {
 export const Default: Story = {
   args: {
     onClick: () => console.log(0),
-    $type: "display",
+    $type: "DISPLAY",
     $isDisabled: false,
     componentName: "컴포넌트 명",
     descriptionText: "설명 내용",

--- a/src/stories/Card/Card.component.stories.tsx
+++ b/src/stories/Card/Card.component.stories.tsx
@@ -50,6 +50,8 @@ function CardContainer(StoryFn: () => JSX.Element) {
 
 export const Default: Story = {
   args: {
+    onClick: () => console.log(0),
+    $type: "display",
     $isDisabled: false,
     componentName: "컴포넌트 명",
     descriptionText: "설명 내용",

--- a/src/types/component.ts
+++ b/src/types/component.ts
@@ -1,0 +1,19 @@
+export interface IComponentData {
+  id: number;
+  title: string;
+  thumbnailUrl: string;
+  type: "input" | "display" | "feedback" | "navigation";
+  introduction: string;
+  designReferenceCount: number;
+  commentCount: number;
+  bookmarkCount: number;
+}
+
+export interface IPageData {
+  pageSize: number;
+  hasNext: boolean;
+  pageNumber: number;
+  totalPages: number;
+  totalElements: number;
+  content: IComponentData[];
+}

--- a/src/types/component.ts
+++ b/src/types/component.ts
@@ -2,7 +2,7 @@ export interface IComponentData {
   id: number;
   title: string;
   thumbnailUrl: string;
-  type: "input" | "display" | "feedback" | "navigation";
+  type: "INPUT" | "DISPLAY" | "FEEDBACK" | "NAVIGATION";
   introduction: string;
   designReferenceCount: number;
   commentCount: number;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] component page 내 component list 구현 (무한 스크롤)

## ✨ 작업 상세 설명

> component page 내의 component list를 `무한 스크롤`로 구현했습니다. 현재는 default 값인 `이름순/오름차순`으로 정렬되고 있으며, 추후 정렬은 따로 구현할 예정입니다. 구현 화면은 아래와 같습니다.

![component list](https://github.com/user-attachments/assets/d6dbe668-cf45-4c2c-a869-55b045c95ee0)

### 🔥 문제 상황 (선택)

_**1. InfinityQuery Type error**_

> `infinityQuery` 사용 중 `queryFn`에서 지속적으로 `Type error: No overload matches this call.`가 발생했습니다. 

```
  Type error: No overload matches this call.
  Overload 1 of 3, '(options: DefinedInitialDataInfiniteOptions<PageData, Error, InfiniteData<PageData, unknown>,
  Overload 2 of 3, '(options: UndefinedInitialDataInfiniteOptions<PageData, Error, InfiniteData<PageData, unknown>, readonly unknown[], unknown>, queryClient?: QueryClient | undefined): UseInfiniteQueryResult<...>', gave the following error.
  Overload 3 of 3, '(options: UseInfiniteQueryOptions<PageData, Error, InfiniteData<PageData, unknown>, PageData, readonly unknown[], unknown>, queryClient?: QueryClient | undefined): UseInfiniteQueryResult<...>', gave the following error.
```

_**2. badge type**_

> API에서 **badge type이 upper case로** 전달되고 있습니다.

### 💦 해결 방법 (선택)

> `unknown` 타입에 `number` 타입인 pageParam을 전달할 수 없어 발생한 에러였습니다. pageParam의 타입을 `number | unknown`으로 정의해 주고 `page`의 타입에 따라 값을 넘겨 주었더니 해결되었습니다. :>

```ts
interface IPageParam {
  pageParam: number | unknown;
}

export const useComponentList = () => {
  const fetchComponents = async ({
    pageParam,
  }: IPageParam): Promise<IPageData> => {
    // number일 때만 pageParam의 값을 넘기고, number가 아닐 경우 0으로 값을 초기화
    const page = typeof pageParam === "number" ? pageParam : 0;
    const data = await searchComponent(page, 10);

    return data;
  };

  return useInfiniteQuery<IPageData, Error, InfiniteData<IPageData>>({
    queryKey: ["components"],
    queryFn: fetchComponents,
    initialPageParam: 0,
    getNextPageParam: (lastPage) =>
      lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,
  });
};
```

_**2. badge type**_

> 모든 `$type의 key`를 **대문자로** 변경해 주었습니다. `type`을 `type.toLowerCase()`로 변경하는 방법도 존재하지만, 이렇게 되면 `string` 타입으로 변환되어 `$type`이 포함되는 모든 컴포넌트들의 타입 정의를 `string`으로 변경해 주어야 하기 때문에 앞서 말한 것처럼 해결해 주었습니다.

```ts
export const BADGE_COMPONENT_TYPE_COLOR = {
  INPUT: "cyan",
  DISPLAY: "violet",
  FEEDBACK: "rose",
  NAVIGATION: "lime",
};
```

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

_**구현**_
[useInfiniteQuery 사용법](https://velog.io/@ggong/useInfiniteQuery-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)
[React Query와 함께하는 Next.js 무한 스크롤](https://velog.io/@hdpark/React-Query%EC%99%80-%ED%95%A8%EA%BB%98%ED%95%98%EB%8A%94-Next.js-%EB%AC%B4%ED%95%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4)

_**에러**_
[React-query infiniteQuery - how to fix additional pageParam type checking](https://stackoverflow.com/questions/78015190/react-query-infinitequery-how-to-fix-additional-pageparam-type-checking)

## 📢 리뷰 요구 사항 (선택)
