### PR TITLE
[✨feat]: 회원가입시 닉네임 유효성 검사 로직 추가

### DIFF
--- a/src/components/Pages/Signup/SignupButton/SignupButton.tsx
+++ b/src/components/Pages/Signup/SignupButton/SignupButton.tsx
@@ -5,13 +5,14 @@ import { useSignupUserStore } from "@/hooks/store/useSignupUserStore";
 import SignupJobs from "@/types/enum/signupJobs";
 import { useSignupMutation } from "@/hooks/api/useSignupMutation";
 import { useRouter } from "next/navigation";
+import validateNickname from "@/utils/validateNickname";
 import * as S from "./SignupButton.style";
 
 export default function SignupButton() {
   const router = useRouter();
   const { nickname, job, socialAccountId, cancelSignup } = useSignupUserStore();
   const isSubmitDisabled =
-    !nickname || job === SignupJobs.NONE || !socialAccountId;
+    !nickname || job === SignupJobs.NONE || !validateNickname(nickname);
 
   const { mutate: signupMutate, isPending, isError } = useSignupMutation();
 

--- a/src/components/Pages/Signup/SignupProfile/SignupProfileNickname.tsx
+++ b/src/components/Pages/Signup/SignupProfile/SignupProfileNickname.tsx
@@ -1,10 +1,20 @@
 import { Button, InputField } from "@/components";
 import { ButtonStyle } from "@/components/Button/Button.types";
 import { useSignupUserStore } from "@/hooks/store/useSignupUserStore";
+import { useState } from "react";
+import validateNickname from "@/utils/validateNickname";
 import * as S from "./SignupProfileNickname.style";
 
 export default function SignupProfileNickname() {
   const { nickname, setNickname } = useSignupUserStore();
+  const [isNickNameValid, setIsNickNameValid] = useState(true);
+
+  function handleNicknameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const input = event.target.value;
+
+    setIsNickNameValid(validateNickname(input));
+    setNickname(input);
+  }
 
   return (
     <S.SignupProfileNicknameInputContainer>
@@ -21,16 +31,19 @@ export default function SignupProfileNickname() {
           </S.SignupProfileNicknameInputLabel>
         }
         $helperVisible
+        // TODO: 유효성 검사에 따라 helperText 기획명세에 맞게 변경
         helperText="특수문자, 공백 제외. 한글, 영문, 숫자로 10자 이내만 가능해요."
         countLimit="10"
         $style={{ flex: "1 0 0" }}
+        $isNegative={!isNickNameValid}
         value={nickname}
-        onChange={(event) => setNickname(event.target.value)}
+        onChange={(event) => handleNicknameChange(event)}
       />
       <Button
         text="중복 검사"
         $size="md"
         $buttonStyle={ButtonStyle.OutlinedPrimary}
+        $isDisabled={!isNickNameValid}
       />
     </S.SignupProfileNicknameInputContainer>
   );

--- a/src/utils/validateNickname.ts
+++ b/src/utils/validateNickname.ts
@@ -1,0 +1,12 @@
+export default function validateNickname(input: string): boolean {
+  // 빈 문자열 체크
+  if (!input) return false;
+
+  // 길이 체크 (10자 이내)
+  if (input.length >= 10) return false;
+
+  // 한글, 영문, 숫자만 허용하는 정규식
+  const regex = /^[가-힣a-zA-Z0-9]+$/;
+
+  return regex.test(input);
+}


### PR DESCRIPTION
## 🚀 작업 내용

- 회원가입 페이지에서 닉네임 입력에 대한 유효성 검사 로직을 추가했습니다.

## ✨ 작업 상세 설명

- 닉네임에 특수문자나 공백이 포함된 경우, 10자 이내가 아닌 경우, 영문/숫자/한글이 아닌 경우 
=> 버튼 Disable 및 InputField Negative 표시함
![image](https://github.com/user-attachments/assets/468cf870-4118-4044-a5c6-62c675f2db45)

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

- [ ] figma랑 disabled시의 버튼 색상이 다르다.
![image](https://github.com/user-attachments/assets/5b1c3a20-5705-497e-b49f-cdfa7e2b0496)
- [ ] `helperText`가 어떤 유효성에 걸리느냐에 따라서 달라져야 함 (기능 명세에는 `시스템 알럿`으로 표시된다고 되어있지만 디자인 상으로는 `helperText`로 표시됨) => 이 부분은 논의가 필요할듯? 하지만 우선순위가 높지는 않아서 일단 보류함

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
