### PR TITLE
[✨feat]: component detail page 세부 내용 표시

### DIFF
--- a/src/api/componentDetail.ts
+++ b/src/api/componentDetail.ts
@@ -1,0 +1,11 @@
+import END_POINT from "@/constants/api";
+import axiosInstance from "./interceptor";
+
+// eslint-disable-next-line import/prefer-default-export
+export const componentDetail = async (componentId: number) => {
+  const { data } = await axiosInstance.get(
+    `${END_POINT.componentDetail(componentId)}`,
+  );
+
+  return data;
+};

--- a/src/app/component/[componentId]/page.tsx
+++ b/src/app/component/[componentId]/page.tsx
@@ -9,7 +9,10 @@ import {
 } from "@/components";
 import { useParams } from "next/navigation";
 import { DocumentSection } from "@/components/Pages";
-import { NAVBAR_ITEM_TEXT } from "@/constants/messages";
+import {
+  COMPONENT_DETAIL_PAGE_TEXT,
+  NAVBAR_ITEM_TEXT,
+} from "@/constants/messages";
 import useComponentDetailQuery from "@/hooks/api/componentDetail/useComponentDetailQuery";
 
 export default function ComponentDetail() {
@@ -19,7 +22,7 @@ export default function ComponentDetail() {
   const { data, isLoading, isError } = useComponentDetailQuery(componentId);
 
   if (!data || isError) {
-    return <EmptyState text="컴포넌트 세부 내용을 불러올 수 없어요" />;
+    return <EmptyState text={COMPONENT_DETAIL_PAGE_TEXT.error} />;
   }
 
   return (
@@ -42,7 +45,7 @@ export default function ComponentDetail() {
         descriptionText={data.blocks.DESCRIPTION[0].content}
         useCaseText={data.blocks.USE_CASE[0].content}
       />
-      {isLoading && <EmptyState text="컴포넌트 세부 내용을 로드 중이에요" />}
+      {isLoading && <EmptyState text={COMPONENT_DETAIL_PAGE_TEXT.error} />}
       <Footer />
     </Layout>
   );

--- a/src/app/component/[componentId]/page.tsx
+++ b/src/app/component/[componentId]/page.tsx
@@ -1,8 +1,27 @@
-import { Layout, NavigationBar, DocumentBanner, Footer } from "@/components";
+"use client";
+
+import {
+  Layout,
+  NavigationBar,
+  DocumentBanner,
+  Footer,
+  EmptyState,
+} from "@/components";
+import { useParams } from "next/navigation";
 import { DocumentSection } from "@/components/Pages";
 import { NAVBAR_ITEM_TEXT } from "@/constants/messages";
+import useComponentDetailQuery from "@/hooks/api/componentDetail/useComponentDetailQuery";
 
 export default function ComponentDetail() {
+  const params = useParams();
+  const componentId = Number(params.componentId);
+
+  const { data, isLoading, isError } = useComponentDetailQuery(componentId);
+
+  if (!data || isError) {
+    return <EmptyState text="컴포넌트 세부 내용을 불러올 수 없어요" />;
+  }
+
   return (
     <Layout>
       <NavigationBar
@@ -11,20 +30,19 @@ export default function ComponentDetail() {
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />
       <DocumentBanner
-        titleText="아코디언 Accoridion"
-        componentListText="확장 패널 Expansion Panel, 토글 패널 Toggle Panel, 콜랩스 Collapse, 디스클로저 Disclosure, 드롭다운 섹션 Dropdown Section, 디테일 Details, 확장 기능 Expander"
-        bodyText="아코디언은 추가적인 정보를 숨기거나 표시하는 데에 사용되는 컴포넌트예요."
+        $src={data.thumbnailUrl}
+        titleText={data.title}
+        componentListText={data.mixedNames.join(", ")}
+        bodyText={data.introduction}
+        commentCount={data.commentCount.toString()}
+        bookmarkCount={data.commentCount.toString()}
       />
       <DocumentSection
-        designReferenceCount={124}
-        descriptionText="아코디언은 추가 정보를 표시하거나 숨기기 위해 상호작용 가능한
-                  제목들이 수직으로 쌓인 UI 구성 요소입니다. 각 항목은 짧은 라벨만
-                  보이도록 ‘접기’ 상태로 유지되거나, 전체 내용을 보기 위해 ‘펼치기’
-                  상태로 전환될 수 있어요."
-        useCaseText="검색 기능 화면에서 검색 결과가 표시될 때, 항목 별로 아코디언을
-                    사용해 표시합니다. 이때, 동시에 여러 아코디언을 자유롭게 확장하고
-                    축소할 수 있습니다."
+        designReferenceCount={data.designReferenceCount}
+        descriptionText={data.blocks.DESCRIPTION[0].content}
+        useCaseText={data.blocks.USE_CASE[0].content}
       />
+      {isLoading && <EmptyState text="컴포넌트 세부 내용을 로드 중이에요" />}
       <Footer />
     </Layout>
   );

--- a/src/app/component/[componentId]/page.tsx
+++ b/src/app/component/[componentId]/page.tsx
@@ -45,7 +45,7 @@ export default function ComponentDetail() {
         descriptionText={data.blocks.DESCRIPTION[0].content}
         useCaseText={data.blocks.USE_CASE[0].content}
       />
-      {isLoading && <EmptyState text={COMPONENT_DETAIL_PAGE_TEXT.error} />}
+      {isLoading && <EmptyState text={COMPONENT_DETAIL_PAGE_TEXT.loading} />}
       <Footer />
     </Layout>
   );

--- a/src/components/Banner/Banner.document.tsx
+++ b/src/components/Banner/Banner.document.tsx
@@ -11,6 +11,8 @@ export default function DocumentBanner({
   titleText,
   componentListText,
   bodyText,
+  commentCount,
+  bookmarkCount,
 }: IDocumentBanner) {
   return (
     <S.BannerContainer>
@@ -25,14 +27,14 @@ export default function DocumentBanner({
           </S.DisplayContainer>
           <S.ButtonContainer>
             <Button
-              text="댓글 보기"
+              text={commentCount}
               $size="lg"
               $buttonType="button"
               $leftIcon={chatIcon}
               $buttonStyle={ButtonStyle.OutlinedSecondary}
             />
             <Button
-              text="북마크 하기"
+              text={bookmarkCount}
               $size="lg"
               $buttonType="button"
               $leftIcon={bookmarkIcon}

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -15,6 +15,8 @@ export interface IDocumentBanner extends IDocumentBannerComponent {
   titleText: TPropsText;
   componentListText: TPropsText;
   bodyText: TPropsText;
+  commentCount: TPropsText;
+  bookmarkCount: TPropsText;
 }
 
 export interface IDocumentBannerComponent {

--- a/src/components/Card/Card.component.style.tsx
+++ b/src/components/Card/Card.component.style.tsx
@@ -18,6 +18,8 @@ export const CardContainer = styled.div<ICardComponent>`
 
   background: ${({ theme }) => theme.light["surface-embossed"]};
 
+  cursor: pointer;
+
   ${({ theme, $isDisabled }) => {
     if ($isDisabled) {
       return css`

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -127,6 +127,8 @@ export const COMPONENT_DETAIL_PAGE_TEXT = {
     title: "개의 디자인 시스템에서 이 컴포넌트를 사용하고 있어요",
     buttonLabel: "보러 가기",
   },
+  loading: "컴포넌트 세부 내용을 로드 중이에요",
+  error:"컴포넌트 세부 내용을 불러올 수 없어요" 
 };
 
 export const COMPONENT_PAGE_TEXT = {

--- a/src/hooks/api/component/useComponentListInfiniteQuery.ts
+++ b/src/hooks/api/component/useComponentListInfiniteQuery.ts
@@ -8,9 +8,7 @@ interface IPageParam {
 
 // eslint-disable-next-line import/prefer-default-export
 export const useComponentListInfiniteQuery = () => {
-  const fetchComponents = async ({
-    pageParam,
-  }: IPageParam): Promise<IPageData> => {
+  const fetchComponents = async ({ pageParam }: IPageParam) => {
     const page = typeof pageParam === "number" ? pageParam : 0;
     const data = await searchComponent(page, 10);
 

--- a/src/hooks/api/component/useComponentListInfiniteQuery.ts
+++ b/src/hooks/api/component/useComponentListInfiniteQuery.ts
@@ -8,7 +8,7 @@ interface IPageParam {
 
 // eslint-disable-next-line import/prefer-default-export
 export const useComponentListInfiniteQuery = () => {
-  const fetchComponents = async ({ pageParam }: IPageParam) => {
+  const fetchComponentList = async ({ pageParam }: IPageParam) => {
     const page = typeof pageParam === "number" ? pageParam : 0;
     const data = await searchComponent(page, 10);
 
@@ -17,7 +17,7 @@ export const useComponentListInfiniteQuery = () => {
 
   return useInfiniteQuery<IPageData, Error, InfiniteData<IPageData>>({
     queryKey: ["components"],
-    queryFn: fetchComponents,
+    queryFn: fetchComponentList,
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,

--- a/src/hooks/api/componentDetail/useComponentDetailQuery.tsx
+++ b/src/hooks/api/componentDetail/useComponentDetailQuery.tsx
@@ -1,0 +1,18 @@
+import { componentDetail } from "@/api/componentDetail";
+import { IComponentDetail } from "@/types/componentDetail";
+import { useQuery } from "@tanstack/react-query";
+
+const useComponentDetailQuery = (componentId: number) => {
+  const fetchComponenetDetail = async () => {
+    const response = await componentDetail(componentId);
+    return response;
+  };
+
+  return useQuery<unknown, Error, IComponentDetail>({
+    queryKey: ["componentDetail", componentId],
+    queryFn: fetchComponenetDetail,
+    enabled: !!componentId,
+  });
+};
+
+export default useComponentDetailQuery;

--- a/src/stories/Banner/Banner.document.stories.tsx
+++ b/src/stories/Banner/Banner.document.stories.tsx
@@ -8,17 +8,6 @@ const meta = {
     layout: "centered",
   },
   tags: ["autodocs"],
-  argTypes: {
-    titleText: {
-      control: { type: "text" },
-    },
-    componentListText: {
-      control: { type: "text" },
-    },
-    bodyText: {
-      control: { type: "text" },
-    },
-  },
 } satisfies Meta<typeof DocumentBanner>;
 
 export default meta;
@@ -30,5 +19,7 @@ export const Default: Story = {
     titleText: "컴포넌트 명",
     componentListText: "혼용되는 컴포넌트 이름 목록",
     bodyText: "컴포넌트에 대한 설명",
+    commentCount: "0",
+    bookmarkCount: "0",
   },
 };

--- a/src/types/componentDetail.ts
+++ b/src/types/componentDetail.ts
@@ -1,0 +1,19 @@
+export interface IDescription {
+  order: number;
+  content: string;
+}
+
+export interface IComponentDetail {
+  title: string;
+  blocks: {
+    DESCRIPTION: IDescription[];
+    USE_CASE: IDescription[];
+  };
+  mixedNames: string[];
+  introduction: string;
+  commentCount: number;
+  bookmarkCount: number;
+  designReferenceCount: number;
+  thumbnailUrl: string;
+  isBookmarked: boolean;
+}


### PR DESCRIPTION
## 🚀 작업 내용

- [x] component detail page 세부 내용 표시
  - [x] useComponentDetailQuery hook 구현
  - [x] document banner component prop 추가 (`commentCount/bookmarkCount`)

## ✨ 작업 상세 설명

> component detail page 세부 내용 표시 구현이 완료되었습니다. [기능 명세서](https://www.notion.so/1204-97fc832ca93b42c8a0479f353723fd6d) 비고에 적혀 있는 것처럼 댓글 및 북마크는 구현되지 않은 상태이니 참고 부탁드립니다. 댓글 및 북마크 버튼 인터랙션은 작동하며, 클릭 시 이벤트는 발생하지 않습니다. (동영 님과 논의 후 결정한 사항입니다! :>)

![component detail page](https://github.com/user-attachments/assets/c81d34ed-f539-4056-b881-d142a160de75)

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

> 디자인 시스템 페이지가 아직 미구현된 상태라 `보러 가기` 버튼을 클릭해도 라우팅이 이루어지지 않습니다. 디자인 시스템 페이지 구현 완료되는 대로 추가 구현 예정입니다.

![스크린샷 2025-02-06 오후 6 50 02](https://github.com/user-attachments/assets/5a4b1a1e-ed66-46a1-9bed-f75f61dddf1e)

## 📄 REFERENCE (선택)

[NEXT.JS useParams 공식 문서](https://nextjs.org/docs/app/api-reference/functions/use-params)

## 📢 리뷰 요구 사항 (선택)
