### PR TITLE
[👽fix]: component list API 변경에 따른 수정

### DIFF
--- a/src/api/component.ts
+++ b/src/api/component.ts
@@ -2,15 +2,14 @@ import END_POINT from "@/constants/api";
 import axiosInstance from "./interceptor";
 
 // eslint-disable-next-line import/prefer-default-export
-export const searchComponent = async (
+export const getComponentList = async (
   page: number,
   size: number,
-  types?: string,
-  keyword?: string,
-  sort?: string,
+  types: string,
+  sort: string,
 ) => {
   const { data } = await axiosInstance.get(
-    `${END_POINT.searchComponent(page, size, types, keyword, sort)}`,
+    `${END_POINT.componentList(page, size, types, sort)}`,
   );
 
   return data;

--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -22,7 +22,7 @@ import { MainContainer } from "@/components/Pages";
 import useChipStore from "@/store/component/useChipStore";
 import useContextMenuStore from "@/store/common/useContextMenuStore";
 import { useObserver } from "@/hooks/api/common/useObserver";
-import { useComponentListInfiniteQuery } from "@/hooks/api/component/useComponentListInfiniteQuery";
+import useComponentListInfiniteQuery from "@/hooks/api/component/useComponentListInfiniteQuery";
 import {
   COMPONENT_SORT_CONDITION,
   COMPONENT_FILTER_TYPE,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -29,14 +29,12 @@ const END_POINT = {
 
   /* component end point */
   componentDetail: (componentId: number) => `/components/${componentId}`,
-  searchComponent: (
+  componentList: (
     page: number = 0,
     size: number = 10,
     types: string = "",
-    keyword: string = "",
     sort: string = "asc",
-  ) =>
-    `/components/search?keyword=${keyword}&types=${types}&page=${page}&size=${size}&sort=${sort}`,
+  ) => `/components?&types=${types}&page=${page}&size=${size}&sort=${sort}`,
 
   /* notice end point */
   notice: "/notices",

--- a/src/hooks/api/component/useComponentListInfiniteQuery.ts
+++ b/src/hooks/api/component/useComponentListInfiniteQuery.ts
@@ -1,29 +1,30 @@
 import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
-import { searchComponent } from "@/api/component";
+import { getComponentList } from "@/api/component";
 import { IPageData } from "@/types/api/component";
 
 interface IPageParam {
   pageParam: number | unknown;
 }
 
-// eslint-disable-next-line import/prefer-default-export
-export const useComponentListInfiniteQuery = (
-  type: string,
+const useComponentListInfiniteQuery = (
+  types: string,
   selectedChips: number[],
   sort: string,
 ) => {
   const fetchComponentList = async ({ pageParam }: IPageParam) => {
     const page = typeof pageParam === "number" ? pageParam : 0;
-    const data = await searchComponent(page, 10, type, "", sort);
+    const data = await getComponentList(page, 10, types, sort);
 
     return data;
   };
 
   return useInfiniteQuery<IPageData, Error, InfiniteData<IPageData>>({
-    queryKey: ["components", type, selectedChips, sort],
+    queryKey: ["components", types, selectedChips, sort],
     queryFn: fetchComponentList,
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,
   });
 };
+
+export default useComponentListInfiniteQuery;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] component list API end point 변경 (`@/constants/api.ts`)
- [x] component list API 요청 함수명 `searchComponent → getComponentList` 변경 (`@/api/component.ts`)
- [x] useComponentListInfiniteQuery hook 불필요한 prop 제거 (`@/hooks/api/component/useComponentListInfiniteQuery.ts`)

## ✨ 작업 상세 설명

> component list API가 변경되어 요청 시 end point 및 함수명을 수정해 주었습니다. 

### @/constants/api.ts

```ts
  componentList: (
    page: number = 0,
    size: number = 10,
    types: string = "",
    sort: string = "asc",
  ) => `/components?&types=${types}&page=${page}&size=${size}&sort=${sort}`,
```

### @/api/component.ts

```ts
export const getComponentList = async (
  page: number,
  size: number,
  types: string,
  sort: string,
) => {
  const { data } = await axiosInstance.get(
    `${END_POINT.componentList(page, size, types, sort)}`,
  );

  return data;
};
```

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
