### PR TITLE
[✨feat]: design system page 목록 미구현 항목 추가 구현

### DIFF
--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -9,7 +9,11 @@ import {
   Footer,
   EmptyState,
 } from "@/components";
-import { BANNER_TEXT, DESIGNSYSTEM_PAGE_TEXT } from "@/constants/messages";
+import {
+  BANNER_TEXT,
+  DESIGNSYSTEM_PAGE_TEXT,
+  NAVBAR_ITEM_TEXT,
+} from "@/constants/messages";
 import { useTokenStore } from "@/hooks/store/useTokenStore";
 import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
 import { useRef } from "react";
@@ -44,7 +48,7 @@ export default function DesignSystem() {
       <NavigationBar
         $isAuthorized={!!accessToken}
         $isSeparated
-        placeholderText="컴포넌트나 디자인 시스템을 검색해 보세요..."
+        placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />
       <DefaultBanner
         titleText={BANNER_TEXT.designSystem.titleText}

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -23,6 +23,7 @@ import {
   DesignSystemCard,
 } from "@/components/Pages";
 import { IDesignSystemData } from "@/types/api/designSystem";
+import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 
 export default function DesignSystem() {
   const { accessToken } = useTokenStore();
@@ -54,7 +55,7 @@ export default function DesignSystem() {
         titleText={BANNER_TEXT.designSystem.titleText}
         descriptionText={BANNER_TEXT.designSystem.descriptionText}
       />
-      <Toolbar>
+      <Toolbar contextMenuItemLabels={COMPONENT_CONTEXT_MENU_ITEM_LABELS}>
         <ButtonList />
       </Toolbar>
       <DesignSystemCardContainer>
@@ -64,7 +65,7 @@ export default function DesignSystem() {
               key={designSystemData.name}
               designSystem={designSystemData}
             />
-          ))
+          )),
         )}
       </DesignSystemCardContainer>
       {isLoading && <EmptyState text={DESIGNSYSTEM_PAGE_TEXT.loading} />}

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -21,6 +21,7 @@ import { useObserver } from "@/hooks/api/common/useObserver";
 import {
   DesignSystemCardContainer,
   DesignSystemCard,
+  MainContainer,
 } from "@/components/Pages";
 import { IDesignSystemData } from "@/types/api/designSystem";
 import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
@@ -68,8 +69,16 @@ export default function DesignSystem() {
           )),
         )}
       </DesignSystemCardContainer>
-      {isLoading && <EmptyState text={DESIGNSYSTEM_PAGE_TEXT.loading} />}
-      {isError && <EmptyState text={DESIGNSYSTEM_PAGE_TEXT.error} />}
+      {isLoading && (
+        <MainContainer>
+          <EmptyState text={DESIGNSYSTEM_PAGE_TEXT.loading} />
+        </MainContainer>
+      )}
+      {isError && (
+        <MainContainer>
+          <EmptyState text={DESIGNSYSTEM_PAGE_TEXT.error} />
+        </MainContainer>
+      )}
       <div ref={lastElementRef} />
       <Footer />
     </Layout>

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import {
   Layout,
   NavigationBar,
@@ -16,7 +17,6 @@ import {
 } from "@/constants/messages";
 import { useTokenStore } from "@/hooks/store/useTokenStore";
 import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
-import { useRef } from "react";
 import { useObserver } from "@/hooks/api/common/useObserver";
 import {
   DesignSystemCardContainer,

--- a/src/components/Card/Card.designSystem.style.ts
+++ b/src/components/Card/Card.designSystem.style.ts
@@ -78,8 +78,7 @@ export const ComponentImage = styled.div<{ $src?: string }>`
   flex: 1 0 0;
   align-self: stretch;
 
-  background-image: ${(props) =>
-    props.$src ? `url(${props.$src})` : `url("/image/sampleImage.png")`};
+  background-image: ${(props) => props.$src && `url(${props.$src})`};
 
   background-color: #ffeede;
   background-size: cover;

--- a/src/components/Card/Card.designSystem.style.ts
+++ b/src/components/Card/Card.designSystem.style.ts
@@ -46,12 +46,14 @@ export const CardContainer = styled.div<ICardComponent>`
 export const TopSection = styled.section`
   display: flex;
   align-items: flex-start;
+  flex: 1 0 0;
+  
   position: relative;
+  width: 100%;
 
   gap: ${DESIGN_SYSTEM.gap.md};
   padding: ${DESIGN_SYSTEM.gap.none};
 
-  flex: 1 0 0;
 `;
 
 export const ImageBox = styled.div`

--- a/src/components/Card/Card.designSystem.style.ts
+++ b/src/components/Card/Card.designSystem.style.ts
@@ -143,10 +143,6 @@ export const DeviceLabelBox = styled.div`
 
   gap: ${DESIGN_SYSTEM.gap["2xs"]};
   padding: ${DESIGN_SYSTEM.gap.none};
-
-  position: absolute;
-  right: 0rem;
-  top: 0.125rem;
 `;
 
 export const LabelBox = styled.div`

--- a/src/components/Card/Card.designSystem.tsx
+++ b/src/components/Card/Card.designSystem.tsx
@@ -6,6 +6,7 @@ import { ICardComponent, IDesignSystemCard } from "./Card.types";
 import { DisabledInteraction, DimmedScreen } from "./CardInteraction";
 
 export default function CardDesignSystem({
+  $src,
   $isDisabled,
   designSystemName,
   organizationName,
@@ -20,7 +21,7 @@ export default function CardDesignSystem({
       <S.TopSection>
         <S.ImageBox>
           {$isDisabled && <DimmedScreen />}
-          <S.ComponentImage />
+          <S.ComponentImage $src={$src} />
         </S.ImageBox>
         <S.ContentContainer>
           <S.ContentBox>

--- a/src/components/Card/Card.designSystem.tsx
+++ b/src/components/Card/Card.designSystem.tsx
@@ -15,10 +15,11 @@ export default function CardDesignSystem({
   labels,
   platformButtons,
   $bookmarkCount,
+  onClick,
 }: IDesignSystemCard & ICardComponent) {
   return (
     <S.CardContainer $isDisabled={$isDisabled}>
-      <S.TopSection>
+      <S.TopSection onClick={onClick}>
         <S.ImageBox>
           {$isDisabled && <DimmedScreen />}
           <S.ComponentImage $src={$src} />

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -28,4 +28,5 @@ export interface IDesignSystemCard {
   labels: React.ReactNode;
   platformButtons: React.ReactNode;
   $bookmarkCount: string;
+  onClick: () => void;
 }

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -41,6 +41,7 @@ export default function DesignSystemCard({
   return (
     <CardDesignSystem
       key={`designSystemcard-${designSystem.name}`}
+      $src={designSystem.thumbnailUrl}
       designSystemName={designSystem.name}
       organizationName={designSystem.organizationName}
       descriptionText={designSystem.description}

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -76,20 +76,29 @@ export default function DesignSystemCard({
         )),
       )}
       platformButtons={platformLabels.map((platformLabel) =>
-        platformLabel.values.map((platformName) => (
-          <Button
-            key={`platformButton-${platformName}`}
-            text={platformName}
-            $size="md"
-            $buttonType="iconButton"
-            $leftIcon={
-              DESIGN_SYSTEM_CHIP_GROUP.platform.contents.find(
-                (content) => content.responseName === platformName,
-              )?.icon
-            }
-            $buttonStyle={ButtonStyle.OutlinedSecondary}
-          />
-        )),
+        platformLabel.values.map((platformName) => {
+          const link = designSystem.links.find(
+            (link) => link.type === platformName.toLowerCase(),
+          );
+
+          return (
+            <Button
+              key={`platformButton-${platformName}`}
+              text={platformName}
+              $size="md"
+              $buttonType="iconButton"
+              onClick={() => {
+                if (link) router.push(link.url);
+              }}
+              $leftIcon={
+                DESIGN_SYSTEM_CHIP_GROUP.platform.contents.find(
+                  (content) => content.responseName === platformName,
+                )?.icon
+              }
+              $buttonStyle={ButtonStyle.OutlinedSecondary}
+            />
+          );
+        }),
       )}
     />
   );

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -21,16 +21,17 @@ export default function DesignSystemCard({
   designSystem: IDesignSystemData;
 }) {
   const deviceLabels = designSystem.filters.filter(
-    (value) => value.type === DesignSystemFilterType.DEVICE
+    (value) => value.type === DesignSystemFilterType.DEVICE,
   );
   const labels = designSystem.filters.filter(
     (value) =>
       value.type === DesignSystemFilterType.TECH ||
-      value.type === DesignSystemFilterType.CONTENT
+      value.type === DesignSystemFilterType.CONTENT,
   );
   const platformLabels = designSystem.filters.filter(
-    (value) => value.type === DesignSystemFilterType.PLATFORM
+    (value) => value.type === DesignSystemFilterType.PLATFORM,
   );
+
 
   return (
     <CardDesignSystem
@@ -38,6 +39,7 @@ export default function DesignSystemCard({
       designSystemName={designSystem.name}
       organizationName={designSystem.organizationName}
       descriptionText={designSystem.description}
+      $src={designSystem.thumbnailUrl}
       $bookmarkCount="999+"
       deviceLabels={deviceLabels.map((deviceLabel) =>
         deviceLabel.values.map((deviceName) => (
@@ -49,7 +51,7 @@ export default function DesignSystemCard({
             $style="solid"
             $size="xs"
           />
-        ))
+        )),
       )}
       labels={labels.map((label) =>
         label.values.map((labelName) => (
@@ -65,7 +67,7 @@ export default function DesignSystemCard({
             $style="transparent"
             $size="xs"
           />
-        ))
+        )),
       )}
       platformButtons={platformLabels.map((platformLabel) =>
         platformLabel.values.map((platformName) => (
@@ -76,12 +78,12 @@ export default function DesignSystemCard({
             $buttonType="iconButton"
             $leftIcon={
               DESIGN_SYSTEM_CHIP_GROUP.platform.contents.find(
-                (content) => content.responseName === platformName
+                (content) => content.responseName === platformName,
               )?.icon
             }
             $buttonStyle={ButtonStyle.OutlinedSecondary}
           />
-        ))
+        )),
       )}
     />
   );

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -45,7 +45,6 @@ export default function DesignSystemCard({
       designSystemName={designSystem.name}
       organizationName={designSystem.organizationName}
       descriptionText={designSystem.description}
-      $src={designSystem.thumbnailUrl}
       onClick={() => router.push(websiteLinks[0].url)}
       $bookmarkCount="999+"
       deviceLabels={deviceLabels.map((deviceLabel) =>

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/navigation";
 import { BadgeLabel, Button, CardDesignSystem } from "@/components";
 import { BadgeLabelFeedback } from "@/components/Badge/Badge.types";
 import { ButtonStyle } from "@/components/Button/Button.types";
@@ -20,6 +21,7 @@ export default function DesignSystemCard({
 }: {
   designSystem: IDesignSystemData;
 }) {
+  const router = useRouter();
   const deviceLabels = designSystem.filters.filter(
     (value) => value.type === DesignSystemFilterType.DEVICE,
   );
@@ -32,6 +34,9 @@ export default function DesignSystemCard({
     (value) => value.type === DesignSystemFilterType.PLATFORM,
   );
 
+  const websiteLinks = designSystem.links.filter(
+    (value) => value.type === "website",
+  );
 
   return (
     <CardDesignSystem
@@ -40,6 +45,7 @@ export default function DesignSystemCard({
       organizationName={designSystem.organizationName}
       descriptionText={designSystem.description}
       $src={designSystem.thumbnailUrl}
+      onClick={() => router.push(websiteLinks[0].url)}
       $bookmarkCount="999+"
       deviceLabels={deviceLabels.map((deviceLabel) =>
         deviceLabel.values.map((deviceName) => (

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -77,7 +77,7 @@ export default function DesignSystemCard({
       )}
       platformButtons={platformLabels.map((platformLabel) =>
         platformLabel.values.map((platformName) => {
-          const link = designSystem.links.find(
+          const platformLink = designSystem.links.find(
             (link) => link.type === platformName.toLowerCase(),
           );
 
@@ -88,7 +88,7 @@ export default function DesignSystemCard({
               $size="md"
               $buttonType="iconButton"
               onClick={() => {
-                if (link) router.push(link.url);
+                if (platformLink) router.push(platformLink.url);
               }}
               $leftIcon={
                 DESIGN_SYSTEM_CHIP_GROUP.platform.contents.find(

--- a/src/stories/Card/Card.designSystem.stories.tsx
+++ b/src/stories/Card/Card.designSystem.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useRouter } from "next/navigation";
 import { BadgeLabel, Button, CardDesignSystem } from "@/components";
 import { BadgeLabelFeedback } from "@/components/Badge/Badge.types";
 import { ButtonStyle } from "@/components/Button/Button.types";
@@ -40,8 +41,11 @@ function CardContainer(StoryFn: () => JSX.Element) {
   );
 }
 
+const router = useRouter();
+
 export const Default: Story = {
   args: {
+    onClick: () => router.push("/"),
     $bookmarkCount: "999+",
     designSystemName: "디자인 시스템 명",
     organizationName: "회사/단체 명",

--- a/src/types/api/component.ts
+++ b/src/types/api/component.ts
@@ -1,12 +1,4 @@
-/* component page API 공통 types입니다. */
-interface ICommonPageData<T> {
-  pageSize: number;
-  hasNext: boolean;
-  pageNumber: number;
-  totalPages: number;
-  totalElements: number;
-  content: T[];
-}
+import ICommonPageData from "@/types/common/pageData";
 
 /* component list API(/components)의 content types입니다. */
 export interface IComponentData {

--- a/src/types/api/designSystem.ts
+++ b/src/types/api/designSystem.ts
@@ -1,24 +1,23 @@
-import { DesignSystemFilterType } from "../enum/designSystemFilters";
+import ICommonPageData from "@/types/common/pageData";
+import { DesignSystemFilterType } from "@/types/enum/designSystemFilters";
 
-export interface IDesignSystemPageData {
-  hasNext: boolean;
-  totalElements: number;
-  totalPages: number;
-  content: IDesignSystemData[];
-  pageNumber: number;
-  pageSize: number;
+interface IDesignSystemLinks {
+  type: string;
+  url: string;
+}
+
+export type IDesignSystemPageData = ICommonPageData<IDesignSystemData>;
+
+export interface IDesignSystemFilter {
+  values: string[];
+  type: DesignSystemFilterType;
 }
 
 export interface IDesignSystemData {
   name: string;
   organizationName: string;
   description: string;
-  filters: IDesignSystemFilter[];
   thumbnailUrl: string;
-  links: [];
-}
-
-export interface IDesignSystemFilter {
-  type: DesignSystemFilterType;
-  values: string[];
+  links: IDesignSystemLinks[];
+  filters: IDesignSystemFilter[];
 }

--- a/src/types/api/designSystem.ts
+++ b/src/types/api/designSystem.ts
@@ -14,6 +14,7 @@ export interface IDesignSystemData {
   organizationName: string;
   description: string;
   filters: IDesignSystemFilter[];
+  thumbnailUrl: string;
   links: [];
 }
 

--- a/src/types/common/pageData.ts
+++ b/src/types/common/pageData.ts
@@ -1,0 +1,8 @@
+export default interface ICommonPageData<T> {
+  pageSize: number;
+  hasNext: boolean;
+  pageNumber: number;
+  totalPages: number;
+  totalElements: number;
+  content: T[];
+}


### PR DESCRIPTION
## 🚀 작업 내용

### 🚀 추가 구현 사항

- [x] design system card 외부 디자인 시스템 **이미지 표시**
- [x] design system card `top section` 클릭 시 **외부 디자인 시스템 페이지로 이동**
  - [x] design system card `platform button` 클릭 시 **외부 디자인 시스템 플랫폼 페이지로 이동**

### 🔨 수정 사항

- [x] design system page **메인 컨테이너 외부에 empty state가 표시되는 문제** 수정
- [x] `device label`이 **title text와 겹쳐 보이는 문제** 수정
- [x] `device label`의 **위치가 카드 레이아웃 내에서 이상하게 표시되는 문제** 수정

## ✨ 작업 상세 설명

> 당장 파악한 미구현 사항 및 수정 사항만 반영해 두었습니다. 잠재적인 문제 및 미구현 사항이 더 있을 수 있으니 나중에 검토 부탁드려요. :> 

### 1. design system card 외부 디자인 시스템 이미지 표시

![스크린샷 2025-02-12 오전 10 41 40](https://github.com/user-attachments/assets/34280eda-1870-4798-a465-b8ec0c94b964)

### 2. design system card 외부 디자인 시스템 페이지 라우팅

_**top section 클릭 시**_
![top section](https://github.com/user-attachments/assets/8768798b-9ab9-43fe-9013-2f60443ab1db)

_**platform button 클릭 시**_

![platform button](https://github.com/user-attachments/assets/b106dd86-42d8-436d-b074-539c8eccdf2f)

### 🔥 문제 상황 (선택)

_**1. device label이 title text와 겹쳐 보이는 문제**_

![스크린샷 2025-02-12 오전 10 46 11](https://github.com/user-attachments/assets/b49c61e9-db7b-491c-b3d4-b5f27ba553db)

_**2. device label의 위치가 카드 레이아웃 내에서 이상하게 표시되는 문제**_

![스크린샷 2025-02-12 오전 10 46 46](https://github.com/user-attachments/assets/4fc9e716-89ed-46f3-a43d-9e932bb2a107)

### 💦 해결 방법 (선택)

_**1. device label이 title text와 겹쳐 보이는 문제**_

> `DeviceLabelBox`에 있던 `position: absoulte` 속성을 제거해 주었습니다.

```css
position: absolute;
right: 0rem;
top: 0.125rem;
```

_**2. device label의 위치가 카드 레이아웃 내에서 이상하게 표시되는 문제**_

> `TopSection`에 `width: 100%` 속성을 추가해 주었습니다.

```
width: 100%
```

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
