### PR TITLE
[✨feat]: design system page 정렬 구현

### DIFF
--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -15,6 +15,7 @@ import {
   DESIGNSYSTEM_PAGE_TEXT,
   NAVBAR_ITEM_TEXT,
 } from "@/constants/messages";
+import { DESIGN_SYSTEM_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 import { useTokenStore } from "@/hooks/store/useTokenStore";
 import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
 import { useObserver } from "@/hooks/api/common/useObserver";
@@ -24,7 +25,6 @@ import {
   MainContainer,
 } from "@/components/Pages";
 import { IDesignSystemData } from "@/types/api/designSystem";
-import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 
 export default function DesignSystem() {
   const { accessToken } = useTokenStore();
@@ -56,7 +56,7 @@ export default function DesignSystem() {
         titleText={BANNER_TEXT.designSystem.titleText}
         descriptionText={BANNER_TEXT.designSystem.descriptionText}
       />
-      <Toolbar contextMenuItemLabels={COMPONENT_CONTEXT_MENU_ITEM_LABELS}>
+      <Toolbar contextMenuItemLabels={DESIGN_SYSTEM_CONTEXT_MENU_ITEM_LABELS}>
         <ButtonList />
       </Toolbar>
       <DesignSystemCardContainer>

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -11,23 +11,27 @@ import {
   EmptyState,
 } from "@/components";
 import {
-  BANNER_TEXT,
-  DESIGNSYSTEM_PAGE_TEXT,
-  NAVBAR_ITEM_TEXT,
-} from "@/constants/messages";
-import { DESIGN_SYSTEM_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
-import { useTokenStore } from "@/hooks/store/useTokenStore";
-import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
-import { useObserver } from "@/hooks/api/common/useObserver";
-import {
   DesignSystemCardContainer,
   DesignSystemCard,
   MainContainer,
 } from "@/components/Pages";
+import {
+  BANNER_TEXT,
+  DESIGNSYSTEM_PAGE_TEXT,
+  NAVBAR_ITEM_TEXT,
+} from "@/constants/messages";
+import { DESIGN_SYSTEM_SORT_CONDITION } from "@/constants/designSystemFilterLabel";
+import { DESIGN_SYSTEM_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
+
+import { useObserver } from "@/hooks/api/common/useObserver";
+import { useTokenStore } from "@/hooks/store/useTokenStore";
+import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
+import useContextMenuStore from "@/store/common/useContextMenuStore";
 import { IDesignSystemData } from "@/types/api/designSystem";
 
 export default function DesignSystem() {
   const { accessToken } = useTokenStore();
+  const { selectedLabel } = useContextMenuStore();
 
   const lastElementRef = useRef<HTMLDivElement | null>(null);
   const {
@@ -36,7 +40,7 @@ export default function DesignSystem() {
     hasNextPage,
     isLoading,
     isError,
-  } = useDesignSystemInfiniteQuery();
+  } = useDesignSystemInfiniteQuery(DESIGN_SYSTEM_SORT_CONDITION[selectedLabel]);
 
   useObserver({
     target: lastElementRef,

--- a/src/components/Pages/DesignSystem/DesignSystemCards.tsx
+++ b/src/components/Pages/DesignSystem/DesignSystemCards.tsx
@@ -46,7 +46,7 @@ export default function DesignSystemCard({
       organizationName={designSystem.organizationName}
       descriptionText={designSystem.description}
       onClick={() => router.push(websiteLinks[0].url)}
-      $bookmarkCount="999+"
+      $bookmarkCount="0"
       deviceLabels={deviceLabels.map((deviceLabel) =>
         deviceLabel.values.map((deviceName) => (
           <BadgeLabel

--- a/src/constants/contextMenuLabels.ts
+++ b/src/constants/contextMenuLabels.ts
@@ -4,6 +4,12 @@ export const COMPONENT_CONTEXT_MENU_ITEM_LABELS = [
   "댓글 순으로 정렬",
 ];
 
+export const DESIGN_SYSTEM_CONTEXT_MENU_ITEM_LABELS = [
+  "이름 순으로 정렬",
+  // "조회 순으로 정렬", → 보류
+  "추천 순으로 정렬",
+];
+
 export const BOOKMARK_CONTEXT_MENU_ITEM_LABELS = [
   "이름 순으로 정렬",
   "조회 순으로 정렬",

--- a/src/constants/designSystemFilterLabel.ts
+++ b/src/constants/designSystemFilterLabel.ts
@@ -4,6 +4,7 @@ import {
   DesignSystemFilterType,
   PlatformFilter,
   TechFilter,
+  DesignSystemSortCondition,
 } from "@/types/enum/designSystemFilters";
 
 // 필터 타입별 레이블
@@ -59,4 +60,10 @@ export const platformFilterLabels: { [key in PlatformFilter]: string } = {
   [PlatformFilter.FIGMA]: "Figma",
   [PlatformFilter.STORYBOOK]: "Storybook",
   [PlatformFilter.ZEROHEIGHT]: "ZeroHeight",
+};
+
+export const DESIGN_SYSTEM_SORT_CONDITION: { [key: string]: string } = {
+  [DesignSystemSortCondition.NAME_ASC]: "summary.name",
+  // [DesignSystemSortCondition.VIEW_DESC]: "", → 보류
+  [DesignSystemSortCondition.RECOMMEND_DESC]: "summary.recommendCount,desc",
 };

--- a/src/hooks/api/designSystem/useDesignSystemInfiniteQuery.ts
+++ b/src/hooks/api/designSystem/useDesignSystemInfiniteQuery.ts
@@ -7,12 +7,12 @@ interface IPageParam {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export const useDesignSystemInfiniteQuery = () => {
+export const useDesignSystemInfiniteQuery = (sort: string) => {
   const fetchDesignSystem = async ({
     pageParam,
   }: IPageParam): Promise<IDesignSystemPageData> => {
     const page = typeof pageParam === "number" ? pageParam : 0;
-    const data = await getDesignSystem(page, 10);
+    const data = await getDesignSystem(page, 10, "", "", sort);
 
     return data;
   };
@@ -22,7 +22,7 @@ export const useDesignSystemInfiniteQuery = () => {
     Error,
     InfiniteData<IDesignSystemPageData>
   >({
-    queryKey: ["designSytem"],
+    queryKey: ["designSytem", sort],
     queryFn: fetchDesignSystem,
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>

--- a/src/types/enum/componentFilter.ts
+++ b/src/types/enum/componentFilter.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export enum ComponentFilterType {
   ALL = 0,
   INPUT = 1,

--- a/src/types/enum/designSystemFilters.ts
+++ b/src/types/enum/designSystemFilters.ts
@@ -50,3 +50,9 @@ export enum PlatformFilter {
   STORYBOOK = "STORYBOOK",
   ZEROHEIGHT = "ZEROHEIGHT",
 }
+
+export enum DesignSystemSortCondition {
+  NAME_ASC = "이름 순으로 정렬",
+  // VIEW_DESC = "조회 순으로 정렬", → 보류
+  RECOMMEND_DESC = "추천 순으로 정렬",
+}


### PR DESCRIPTION
## 🚀 작업 내용

- [x] design system page 정렬 구현 (이름순/추천순)

## ✨ 작업 상세 설명

> design system page 정렬 기능 구현이 완료되었습니다. 자세한 기능 명세는 [기능 명세서 6-2-4](https://www.notion.so/1204-97fc832ca93b42c8a0479f353723fd6d)에서 확인하실 수 있습니다. :> API에는 정렬 조건이 `이름순/추천순`만 구현되어 있어 두 가지 조건만 `context menu labels`에 추가해 두었습니다. 

![design system sort](https://github.com/user-attachments/assets/81218f02-8ca8-477b-98aa-5b263d4367b8)

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
