### PR TITLE
[✨feat]: 프로필 편집 기능 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "printWidth": 80
+  "printWidth": 80,
+  "trailingComma": "all"
 }

--- a/src/api/userInfo.ts
+++ b/src/api/userInfo.ts
@@ -13,15 +13,20 @@ export const getUserInfo = async (accessToken: string) => {
 
 export const putProfileEdit = async (
   accessToken: string,
-  { nickname, profileImageObjectKey, job }: IProfileEdit
+  { nickname, profileImageObjectKey, job }: IProfileEdit,
 ) => {
-  const response = await axiosInstance.put(END_POINT.modifyProfile, {
-    headers: {
-      Authorization: accessToken,
+  const response = await axiosInstance.put(
+    END_POINT.modifyProfile,
+    {
+      profileImageObjectKey,
+      nickname,
+      job,
     },
-    profileImageObjectKey,
-    nickname,
-    job,
-  });
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
   return response;
 };

--- a/src/api/userInfo.ts
+++ b/src/api/userInfo.ts
@@ -1,12 +1,27 @@
 import END_POINT from "@/constants/api";
+import { IProfileEdit } from "@/types/api/user";
 import axiosInstance from "./interceptor";
 
-// eslint-disable-next-line import/prefer-default-export
 export const getUserInfo = async (accessToken: string) => {
   const response = await axiosInstance.get(END_POINT.memberSummary, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
+  });
+  return response;
+};
+
+export const putProfileEdit = async (
+  accessToken: string,
+  { nickname, profileImageObjectKey, job }: IProfileEdit
+) => {
+  const response = await axiosInstance.put(END_POINT.modifyProfile, {
+    headers: {
+      Authorization: accessToken,
+    },
+    profileImageObjectKey,
+    nickname,
+    job,
   });
   return response;
 };

--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/constants/componentFilter";
 import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 import { IComponentData } from "@/types/api/component";
+import { useTokenStore } from "@/hooks/store/useTokenStore";
 
 export default function Component() {
   const router = useRouter();
@@ -36,6 +37,7 @@ export default function Component() {
 
   const { selectedChips } = useChipStore();
   const { selectedLabel } = useContextMenuStore();
+  const { accessToken } = useTokenStore();
 
   const selectedChipNames = selectedChips
     .map((chipIndex) => COMPONENT_FILTER_TYPE[chipIndex])
@@ -58,7 +60,7 @@ export default function Component() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized
+        $isAuthorized={!!accessToken}
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/app/login/signup/page.tsx
+++ b/src/app/login/signup/page.tsx
@@ -9,12 +9,13 @@ import {
   SignupTitle,
   SignupWrapper,
 } from "@/components/Pages";
+import { SIGNUP_TEXT } from "@/constants/messages";
 
 export default function SignupPage() {
   return (
     <SignupWrapper>
       <SignupModuleWrapper>
-        <SignupTitle />
+        <SignupTitle titleText={SIGNUP_TEXT.titleText} />
         <Divider $stroke="normal" $layout="horizontal" />
         <SignupBodyModuleWrapper>
           <SignupProfile />

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,3 +1,30 @@
+import { Divider } from "@/components";
+import {
+  ProfileEditBodyModuleWrapper,
+  ProfileEditButton,
+  ProfileEditJob,
+  ProfileEditModuleWrapper,
+  ProfileEditProfile,
+  ProfileEditWrapper,
+  SignupFooter,
+  SignupTitle,
+} from "@/components/Pages";
+import { PROFILE_EDIT_TEXT } from "@/constants/messages";
+
 export default function Edit() {
-  return <div>Edit</div>;
+  return (
+    <ProfileEditWrapper>
+      <ProfileEditModuleWrapper>
+        <SignupTitle titleText={PROFILE_EDIT_TEXT.titleText} />
+        <Divider $stroke="normal" $layout="horizontal" />
+        <ProfileEditBodyModuleWrapper>
+          <ProfileEditProfile />
+          <ProfileEditJob />
+          <Divider $stroke="normal" $layout="horizontal" />
+          <ProfileEditButton />
+        </ProfileEditBodyModuleWrapper>
+      </ProfileEditModuleWrapper>
+      <SignupFooter />
+    </ProfileEditWrapper>
+  );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -29,7 +29,6 @@ export default function Profile() {
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />
       <ProfileBanner
-        userJob="디자이너"
         emailAddress="아직 인증된 이메일 주소가 없어요."
         loginInfo="Google 소셜"
       />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,9 +10,11 @@ import {
 } from "@/components";
 import { NAVBAR_ITEM_TEXT } from "@/constants/messages";
 import { ProfileContainer, ProfileTab } from "@/components/Pages";
+import { useTokenStore } from "@/hooks/store/useTokenStore";
 
 export default function Profile() {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const { accessToken } = useTokenStore();
 
   const getEmptyStateText = () => {
     if (!selectedTabIndex) return `아직 알림이 없어요`;
@@ -22,12 +24,11 @@ export default function Profile() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized
+        $isAuthorized={!!accessToken}
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />
       <ProfileBanner
-        userName="악악어"
         userJob="디자이너"
         emailAddress="아직 인증된 이메일 주소가 없어요."
         loginInfo="Google 소셜"

--- a/src/components/Banner/Banner.profile.tsx
+++ b/src/components/Banner/Banner.profile.tsx
@@ -1,17 +1,23 @@
+"use client";
+
 import { Avatar, Button } from "@/components";
 import rightIcon from "@/assets/icons/chevron-right-line.svg";
 import { BANNER_TEXT } from "@/constants/messages";
+import { useRouter } from "next/navigation";
+import { useUserInfoStore } from "@/hooks/store/useUserInfoStore";
 import { ButtonStyle } from "../Button/Button.types";
 import * as S from "./Banner.profile.style";
 import { IProfileBanner } from "./Banner.types";
 
 export default function ProfileBanner({
   $src,
-  userName,
   userJob,
   emailAddress,
   loginInfo,
 }: IProfileBanner) {
+  const router = useRouter();
+  const { userInfo } = useUserInfoStore();
+
   return (
     <S.BannerContainer>
       <S.ContentContainer>
@@ -20,7 +26,7 @@ export default function ProfileBanner({
         </S.AvatarBox>
         <S.UserInfoContainer>
           <S.UserNameBox>
-            <S.UserNameText>{userName}</S.UserNameText>
+            <S.UserNameText>{userInfo.nickname}</S.UserNameText>
             <S.UserJobText>{userJob}</S.UserJobText>
           </S.UserNameBox>
           <S.UserEmailBox>
@@ -42,6 +48,7 @@ export default function ProfileBanner({
           $size="sm"
           $buttonStyle={ButtonStyle.OutlinedSecondary}
           $buttonType="button"
+          onClick={() => router.push("/profile/edit")}
         />
       </S.ContentContainer>
     </S.BannerContainer>

--- a/src/components/Banner/Banner.profile.tsx
+++ b/src/components/Banner/Banner.profile.tsx
@@ -5,13 +5,13 @@ import rightIcon from "@/assets/icons/chevron-right-line.svg";
 import { BANNER_TEXT } from "@/constants/messages";
 import { useRouter } from "next/navigation";
 import { useUserInfoStore } from "@/hooks/store/useUserInfoStore";
+import SignupJobs from "@/types/enum/signupJobs";
 import { ButtonStyle } from "../Button/Button.types";
 import * as S from "./Banner.profile.style";
 import { IProfileBanner } from "./Banner.types";
 
 export default function ProfileBanner({
   $src,
-  userJob,
   emailAddress,
   loginInfo,
 }: IProfileBanner) {
@@ -27,7 +27,7 @@ export default function ProfileBanner({
         <S.UserInfoContainer>
           <S.UserNameBox>
             <S.UserNameText>{userInfo.nickname}</S.UserNameText>
-            <S.UserJobText>{userJob}</S.UserJobText>
+            <S.UserJobText>{SignupJobs[userInfo.job]}</S.UserJobText>
           </S.UserNameBox>
           <S.UserEmailBox>
             <S.EmailAddressText>{emailAddress}</S.EmailAddressText>

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -28,7 +28,6 @@ export interface IDocumentBannerComponent {
  */
 export interface IProfileBanner {
   $src?: string;
-  userName: string;
   userJob: string;
   emailAddress: string;
   loginInfo: string;

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -28,7 +28,6 @@ export interface IDocumentBannerComponent {
  */
 export interface IProfileBanner {
   $src?: string;
-  userJob: string;
   emailAddress: string;
   loginInfo: string;
 }

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -23,6 +23,7 @@ export default function InputField({
   $style,
   value,
   onChange,
+  onBlur,
 }: IInputField) {
   const [isFocused, setIsFocused] = useState(false);
 
@@ -55,8 +56,14 @@ export default function InputField({
             placeholder={placeholderText}
             onChange={onChange}
             onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
+            onBlur={(event) => {
+              setIsFocused(false);
+              if (onBlur) {
+                onBlur(event);
+              }
+            }}
           />
+          {/* TODO : PR 78번 확인, 논의 후 수정 예정 */}
           {/* <InteractionContainer
             $variant={InteractionVariant.DEFAULT}
             $density="normal"

--- a/src/components/InputField/InputField.types.ts
+++ b/src/components/InputField/InputField.types.ts
@@ -15,5 +15,6 @@ export interface IInputField extends IInputComponent {
   $helperVisible: boolean;
   $style?: React.CSSProperties;
   value: string;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/components/NavigationBar/NavigationBar.style.ts
+++ b/src/components/NavigationBar/NavigationBar.style.ts
@@ -73,7 +73,7 @@ export const NavItemBox = styled.div`
   padding: ${DESIGN_SYSTEM.gap["3xs"]};
 `;
 
-export const AvatarBox = styled.div`
+export const AvatarBox = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -108,7 +108,7 @@ export default function NavigationBar({
                         labelText={cleanKorean(component.title)}
                         badgeLabelText="컴포넌트"
                         subLabelText={extractKorean(component.mixedNames).join(
-                          ", ",
+                          ", "
                         )}
                         onClick={() => handleItemClick(component.id)}
                       />
@@ -120,13 +120,14 @@ export default function NavigationBar({
                     key="noCondition"
                     text="컴포넌트 검색 결과가 없어요"
                   />
-                ),
+                )
               )}
             </Combobox>
           )}
           {$isAuthorized ? (
             <S.NavItemBox>
-              <S.AvatarBox>
+              {/* TODO: 추후 콤보 박스로 변경해야함. 현재 임시로 Profile 페이지로 이동 */}
+              <S.AvatarBox onClick={() => router.push("/profile")}>
                 <Avatar $size="md" $badgeVisible />
               </S.AvatarBox>
             </S.NavItemBox>

--- a/src/components/Pages/Profile/Edit/ProfileEdit.style.ts
+++ b/src/components/Pages/Profile/Edit/ProfileEdit.style.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const ProfileEditWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex: 1 0 0;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["8xl"]};
+  padding: ${DESIGN_SYSTEM.gap["7xl"]};
+
+  background: ${({ theme }) => theme.light["surface-standard"]};
+`;
+
+export const ProfileEditModule = styled.div`
+  width: 100%;
+  max-width: 35rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  // align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["3xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const ProfileEditBodyModule = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["7xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/components/Pages/Profile/Edit/ProfileEditBodyModuleWrapper.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditBodyModuleWrapper.tsx
@@ -1,0 +1,9 @@
+import * as S from "./ProfileEdit.style";
+
+export default function ProfileEditBodyModuleWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <S.ProfileEditBodyModule>{children}</S.ProfileEditBodyModule>;
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditButton/ProfileEditButton.style.ts
+++ b/src/components/Pages/Profile/Edit/ProfileEditButton/ProfileEditButton.style.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+// eslint-disable-next-line import/prefer-default-export
+export const ProfileEditButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.md};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/components/Pages/Profile/Edit/ProfileEditButton/ProfileEditButton.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditButton/ProfileEditButton.tsx
@@ -1,46 +1,52 @@
 import { Button } from "@/components";
 import { ButtonStyle } from "@/components/Button/Button.types";
 import { PROFILE_EDIT_TEXT } from "@/constants/messages";
+import { useRouter } from "next/navigation";
+import { useProfileEditMutation } from "@/hooks/api/profileEdit/useProfileEditMutation";
+import { useTokenStore } from "@/hooks/store/useTokenStore";
+import { useProfileEditStore } from "@/hooks/store/useProfileEditStore";
+import { useEffect } from "react";
+import { useUserInfoStore } from "@/hooks/store/useUserInfoStore";
 import * as S from "./ProfileEditButton.style";
-// import { useSignupUserStore } from "@/hooks/store/useSignupUserStore";
-// import SignupJobs from "@/types/enum/signupJobs";
-// import { useSignupMutation } from "@/hooks/api/useSignupMutation";
-// import { useRouter } from "next/navigation";
-// import validateNickname from "@/utils/validateNickname";
 
 export default function ProfileEditButton() {
-  // const router = useRouter();
-  // const { nickname, job, socialAccountToken, cancelSignup } =
-  //   useSignupUserStore();
-  // const isSubmitDisabled =
-  //   !nickname || job === SignupJobs.NONE || !validateNickname(nickname);
+  const router = useRouter();
+  const { accessToken } = useTokenStore();
+  const {
+    profileInfo: { nickname, profileImageObjectKey, job },
+    cancelEdit,
+    initializeWithUserInfo,
+  } = useProfileEditStore();
+  const { userInfo } = useUserInfoStore();
 
-  // const { mutate: signupMutate, isPending, isError } = useSignupMutation();
+  const {
+    mutate: profileEditMutate,
+    isPending,
+    isError,
+  } = useProfileEditMutation(accessToken || "");
 
-  // // job 변환 (ex. "개발자" -> "DEVELOPER")
-  // const getJobKey = (jobValue: string) =>
-  //   (Object.entries(SignupJobs).find(
-  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //     ([_, value]) => value === jobValue
-  //   )?.[0] as keyof typeof SignupJobs) || "";
+  useEffect(() => {
+    initializeWithUserInfo(userInfo);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // const handleSignup = () => {
-  //   signupMutate({
-  //     nickname,
-  //     job: getJobKey(job),
-  //     socialAccountToken,
-  //   });
-  // };
+  const handleSubmit = () => {
+    profileEditMutate({
+      nickname,
+      profileImageObjectKey,
+      job,
+    });
+  };
 
-  // // 에러 처리
-  // if (isError) {
-  //   return <div>회원가입 중 오류가 발생했습니다.</div>;
-  // }
+  // 에러 처리
+  if (isError) {
+    return <div>프로필 편집 중 오류가 발생했습니다.</div>;
+  }
 
-  // const handleCancelClick = () => {
-  //   cancelSignup();
-  //   router.push("/");
-  // };
+  const handleCancelClick = () => {
+    cancelEdit();
+    router.push("/profile");
+  };
 
   return (
     <S.ProfileEditButtonContainer>
@@ -48,14 +54,13 @@ export default function ProfileEditButton() {
         text={PROFILE_EDIT_TEXT.cancelButtonText}
         $size="md"
         $buttonStyle={ButtonStyle.OutlinedSecondary}
-        // onClick={handleCancelClick}
+        onClick={handleCancelClick}
       />
       <Button
-        text={PROFILE_EDIT_TEXT.submitButtonText}
+        text={isPending ? "로딩중..." : PROFILE_EDIT_TEXT.submitButtonText}
         $size="md"
         $buttonStyle={ButtonStyle.SolidBrand}
-        // $isDisabled={isSubmitDisabled}
-        // onClick={handleSignup}
+        onClick={handleSubmit}
       />
     </S.ProfileEditButtonContainer>
   );

--- a/src/components/Pages/Profile/Edit/ProfileEditButton/ProfileEditButton.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditButton/ProfileEditButton.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import { PROFILE_EDIT_TEXT } from "@/constants/messages";
+import * as S from "./ProfileEditButton.style";
+// import { useSignupUserStore } from "@/hooks/store/useSignupUserStore";
+// import SignupJobs from "@/types/enum/signupJobs";
+// import { useSignupMutation } from "@/hooks/api/useSignupMutation";
+// import { useRouter } from "next/navigation";
+// import validateNickname from "@/utils/validateNickname";
+
+export default function ProfileEditButton() {
+  // const router = useRouter();
+  // const { nickname, job, socialAccountToken, cancelSignup } =
+  //   useSignupUserStore();
+  // const isSubmitDisabled =
+  //   !nickname || job === SignupJobs.NONE || !validateNickname(nickname);
+
+  // const { mutate: signupMutate, isPending, isError } = useSignupMutation();
+
+  // // job 변환 (ex. "개발자" -> "DEVELOPER")
+  // const getJobKey = (jobValue: string) =>
+  //   (Object.entries(SignupJobs).find(
+  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //     ([_, value]) => value === jobValue
+  //   )?.[0] as keyof typeof SignupJobs) || "";
+
+  // const handleSignup = () => {
+  //   signupMutate({
+  //     nickname,
+  //     job: getJobKey(job),
+  //     socialAccountToken,
+  //   });
+  // };
+
+  // // 에러 처리
+  // if (isError) {
+  //   return <div>회원가입 중 오류가 발생했습니다.</div>;
+  // }
+
+  // const handleCancelClick = () => {
+  //   cancelSignup();
+  //   router.push("/");
+  // };
+
+  return (
+    <S.ProfileEditButtonContainer>
+      <Button
+        text={PROFILE_EDIT_TEXT.cancelButtonText}
+        $size="md"
+        $buttonStyle={ButtonStyle.OutlinedSecondary}
+        // onClick={handleCancelClick}
+      />
+      <Button
+        text={PROFILE_EDIT_TEXT.submitButtonText}
+        $size="md"
+        $buttonStyle={ButtonStyle.SolidBrand}
+        // $isDisabled={isSubmitDisabled}
+        // onClick={handleSignup}
+      />
+    </S.ProfileEditButtonContainer>
+  );
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditJob/ProfileEditJob.style.ts
+++ b/src/components/Pages/Profile/Edit/ProfileEditJob/ProfileEditJob.style.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const ProfileEditJobWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const ProfileEditJobTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const ProfileEditJobTitleText = styled.span`
+  align-self: stretch;
+  color: ${({ theme }) => theme.light["object-hero"]};
+
+  ${DESIGN_SYSTEM.typography.title["2"]}
+`;
+
+export const ProfileEditJobTitleMustIcon = styled.span`
+  color: ${({ theme }) => theme.light["feedback-notification"]};
+
+  ${DESIGN_SYSTEM.typography.title["2"]}
+`;
+
+export const ProfileEditJobBodyText = styled.span`
+  align-self: stretch;
+  color: ${({ theme }) => theme.light["object-bold"]};
+
+  ${DESIGN_SYSTEM.typography.body.sm}
+`;
+
+export const ProfileEditJobChipContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  align-content: flex-start;
+  align-self: stretch;
+  flex-wrap: wrap;
+  gap: ${DESIGN_SYSTEM.gap.xs};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/components/Pages/Profile/Edit/ProfileEditJob/ProfileEditJob.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditJob/ProfileEditJob.tsx
@@ -1,23 +1,30 @@
 import { Chip } from "@/components";
 import { PROFILE_EDIT_TEXT, STAR_ICON } from "@/constants/messages";
 import SignupJobs from "@/types/enum/signupJobs";
-// import { useSignupUserStore } from "@/hooks/store/useSignupUserStore";
+import { useProfileEditStore } from "@/hooks/store/useProfileEditStore";
+import getJobKey from "@/utils/getJobKey";
+import { useUserInfoStore } from "@/hooks/store/useUserInfoStore";
+import { useState } from "react";
 import * as S from "./ProfileEditJob.style";
 
 export default function ProfileEditJob() {
-  // const { job, setJob } = useSignupUserStore();
+  const { userInfo } = useUserInfoStore();
+  const { profileInfo, setProfileInfo } = useProfileEditStore();
+  const [job, setJob] = useState<keyof typeof SignupJobs>(userInfo.job);
 
   const JOB_CHIPS = Object.values(SignupJobs).filter(
-    (val) => val !== SignupJobs.NONE
+    (val) => val !== SignupJobs.NONE,
   );
 
-  // const handleChipClick = (chip: SignupJobs) => {
-  //   if (job === chip) {
-  //     setJob(SignupJobs.NONE);
-  //     return;
-  //   }
-  //   setJob(chip);
-  // };
+  const handleChipClick = (chip: SignupJobs) => {
+    if (profileInfo.job === getJobKey(chip)) {
+      setJob(getJobKey(SignupJobs.NONE));
+      setProfileInfo({ ...profileInfo, job: "NONE" });
+      return;
+    }
+    setJob(getJobKey(chip));
+    setProfileInfo({ ...profileInfo, job: getJobKey(chip) });
+  };
 
   return (
     <S.ProfileEditJobWrapper>
@@ -38,9 +45,9 @@ export default function ProfileEditJob() {
             key={`job-${chip}`}
             text={chip}
             onClick={() => {
-              // handleChipClick(chip)
+              handleChipClick(chip);
             }}
-            // $isSelected={chip === job}
+            $isSelected={getJobKey(chip) === job}
             $size="xl"
           />
         ))}

--- a/src/components/Pages/Profile/Edit/ProfileEditJob/ProfileEditJob.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditJob/ProfileEditJob.tsx
@@ -1,0 +1,50 @@
+import { Chip } from "@/components";
+import { PROFILE_EDIT_TEXT, STAR_ICON } from "@/constants/messages";
+import SignupJobs from "@/types/enum/signupJobs";
+// import { useSignupUserStore } from "@/hooks/store/useSignupUserStore";
+import * as S from "./ProfileEditJob.style";
+
+export default function ProfileEditJob() {
+  // const { job, setJob } = useSignupUserStore();
+
+  const JOB_CHIPS = Object.values(SignupJobs).filter(
+    (val) => val !== SignupJobs.NONE
+  );
+
+  // const handleChipClick = (chip: SignupJobs) => {
+  //   if (job === chip) {
+  //     setJob(SignupJobs.NONE);
+  //     return;
+  //   }
+  //   setJob(chip);
+  // };
+
+  return (
+    <S.ProfileEditJobWrapper>
+      <S.ProfileEditJobTitleContainer>
+        <S.ProfileEditJobTitleText>
+          {PROFILE_EDIT_TEXT.job.titleText}
+          <S.ProfileEditJobTitleMustIcon>
+            {STAR_ICON}
+          </S.ProfileEditJobTitleMustIcon>
+        </S.ProfileEditJobTitleText>
+        <S.ProfileEditJobBodyText>
+          {PROFILE_EDIT_TEXT.job.bodyText}
+        </S.ProfileEditJobBodyText>
+      </S.ProfileEditJobTitleContainer>
+      <S.ProfileEditJobChipContainer>
+        {JOB_CHIPS.map((chip) => (
+          <Chip
+            key={`job-${chip}`}
+            text={chip}
+            onClick={() => {
+              // handleChipClick(chip)
+            }}
+            // $isSelected={chip === job}
+            $size="xl"
+          />
+        ))}
+      </S.ProfileEditJobChipContainer>
+    </S.ProfileEditJobWrapper>
+  );
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditModuleWrapper.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditModuleWrapper.tsx
@@ -1,0 +1,9 @@
+import * as S from "./ProfileEdit.style";
+
+export default function ProfileEditModuleWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <S.ProfileEditModule>{children}</S.ProfileEditModule>;
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfile.style.ts
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfile.style.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const ProfileEditProfileWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const ProfileEditProfileTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+
+  align-self: stretch;
+
+  color: ${({ theme }) => theme.light["object-hero"]};
+
+  ${DESIGN_SYSTEM.typography.title["2"]}
+`;
+
+export const ProfileEditProfileInputSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["7xl"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfile.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfile.tsx
@@ -1,0 +1,18 @@
+import { PROFILE_EDIT_TEXT } from "@/constants/messages";
+import * as S from "./ProfileEditProfile.style";
+import ProfileEditProfileImage from "./ProfileEditProfileImage";
+import ProfileEditProfileNickname from "./ProfileEditProfileNickname";
+
+export default function ProfileEditProfile() {
+  return (
+    <S.ProfileEditProfileWrapper>
+      <S.ProfileEditProfileTitleContainer>
+        {PROFILE_EDIT_TEXT.profileText}
+      </S.ProfileEditProfileTitleContainer>
+      <S.ProfileEditProfileInputSection>
+        <ProfileEditProfileImage />
+        <ProfileEditProfileNickname />
+      </S.ProfileEditProfileInputSection>
+    </S.ProfileEditProfileWrapper>
+  );
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileImage.style.ts
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileImage.style.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const ProfileEditProfileImageUploadWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.md};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const ProfileEditProfileImageLabel = styled.div`
+  display: flex;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["6xs"]};
+  padding-left: ${DESIGN_SYSTEM.gap["4xs"]};
+
+  color: ${({ theme }) => theme.light["object-normal"]};
+
+  ${DESIGN_SYSTEM.typography.label.xs}
+`;
+
+export const ProfileEditProfileImageHelperCaption = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap.sm};
+  padding: ${DESIGN_SYSTEM.gap.none} ${DESIGN_SYSTEM.gap["4xs"]};
+
+  flex: 1 0 0;
+
+  color: ${({ theme }) => theme.light["object-subtle"]};
+  text-align: center;
+
+  ${DESIGN_SYSTEM.typography.body.xs}
+`;

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileImage.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileImage.tsx
@@ -1,0 +1,22 @@
+import { Avatar, Button } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import * as S from "./ProfileEditProfileImage.style";
+
+export default function ProfileEditProfileImage() {
+  return (
+    <S.ProfileEditProfileImageUploadWrapper>
+      <S.ProfileEditProfileImageLabel>
+        프로필 이미지
+      </S.ProfileEditProfileImageLabel>
+      <Avatar $size="2xl" $badgeVisible={false} />
+      <Button
+        text="이미지 업로드"
+        $size="md"
+        $buttonStyle={ButtonStyle.OutlinedSecondary}
+      />
+      <S.ProfileEditProfileImageHelperCaption>
+        jpg, png 이미지 파일을 업로드 할 수 있어요.
+      </S.ProfileEditProfileImageHelperCaption>
+    </S.ProfileEditProfileImageUploadWrapper>
+  );
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileNickname.style.ts
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileNickname.style.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import DESIGN_SYSTEM from "@/styles/designSystem";
+import styled from "styled-components";
+
+export const ProfileEditProfileNicknameInputContainer = styled.div`
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  gap: ${DESIGN_SYSTEM.gap["2xs"]};
+  padding: ${DESIGN_SYSTEM.gap.none};
+`;
+
+export const ProfileEditProfileNicknameInputLabel = styled.span`
+  color: ${({ theme }) => theme.light["object-normal"]};
+
+  ${DESIGN_SYSTEM.typography.label.xs}
+`;
+
+export const ProfileEditProfileNicknameInputLabelStar = styled.span`
+  color: ${({ theme }) => theme.light["feedback-notification"]};
+
+  ${DESIGN_SYSTEM.typography.label.xs}
+`;

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileNickname.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileNickname.tsx
@@ -1,0 +1,50 @@
+import { Button, InputField } from "@/components";
+import { ButtonStyle } from "@/components/Button/Button.types";
+import { useState } from "react";
+import validateNickname from "@/utils/validateNickname";
+import { useUserInfoStore } from "@/hooks/store/useUserInfoStore";
+import * as S from "./ProfileEditProfileNickname.style";
+
+export default function ProfileEditProfileNickname() {
+  const { userInfo } = useUserInfoStore();
+  const [isNickNameValid, setIsNickNameValid] = useState(true);
+
+  function handleNicknameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const input = event.target.value;
+
+    setIsNickNameValid(validateNickname(input));
+    // setNickname(input);
+  }
+
+  return (
+    <S.ProfileEditProfileNicknameInputContainer>
+      <InputField
+        $size="md"
+        placeholderText="김노트"
+        $labelVisible
+        label={
+          <S.ProfileEditProfileNicknameInputLabel>
+            닉네임
+            <S.ProfileEditProfileNicknameInputLabelStar>
+              *
+            </S.ProfileEditProfileNicknameInputLabelStar>
+          </S.ProfileEditProfileNicknameInputLabel>
+        }
+        $helperVisible
+        // TODO: 유효성 검사에 따라 helperText 기획명세에 맞게 변경
+        helperText="특수문자, 공백 제외. 한글, 영문, 숫자로 10자 이내만 가능해요."
+        countLimit="10"
+        $style={{ flex: "1 0 0" }}
+        // $isNegative={!isNickNameValid}
+        value={userInfo.nickname}
+        onChange={(event) => handleNicknameChange(event)}
+      />
+      <Button
+        text="중복 검사"
+        $size="md"
+        $buttonStyle={ButtonStyle.OutlinedPrimary}
+        $isDisabled={!isNickNameValid}
+      />
+    </S.ProfileEditProfileNicknameInputContainer>
+  );
+}

--- a/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileNickname.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditProfile/ProfileEditProfileNickname.tsx
@@ -2,18 +2,19 @@ import { Button, InputField } from "@/components";
 import { ButtonStyle } from "@/components/Button/Button.types";
 import { useState } from "react";
 import validateNickname from "@/utils/validateNickname";
+import { useProfileEditStore } from "@/hooks/store/useProfileEditStore";
 import { useUserInfoStore } from "@/hooks/store/useUserInfoStore";
 import * as S from "./ProfileEditProfileNickname.style";
 
 export default function ProfileEditProfileNickname() {
   const { userInfo } = useUserInfoStore();
+  const { profileInfo, setProfileInfo } = useProfileEditStore();
   const [isNickNameValid, setIsNickNameValid] = useState(true);
+  const [nickname, setNickname] = useState(userInfo.nickname);
 
-  function handleNicknameChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const input = event.target.value;
-
-    setIsNickNameValid(validateNickname(input));
-    // setNickname(input);
+  function handleNicknameBlur() {
+    setIsNickNameValid(validateNickname(nickname));
+    setProfileInfo({ ...profileInfo, nickname });
   }
 
   return (
@@ -35,9 +36,10 @@ export default function ProfileEditProfileNickname() {
         helperText="특수문자, 공백 제외. 한글, 영문, 숫자로 10자 이내만 가능해요."
         countLimit="10"
         $style={{ flex: "1 0 0" }}
-        // $isNegative={!isNickNameValid}
-        value={userInfo.nickname}
-        onChange={(event) => handleNicknameChange(event)}
+        $isNegative={!isNickNameValid}
+        value={nickname}
+        onChange={(event) => setNickname(event.target.value)}
+        onBlur={() => handleNicknameBlur()}
       />
       <Button
         text="중복 검사"

--- a/src/components/Pages/Profile/Edit/ProfileEditWrapper.tsx
+++ b/src/components/Pages/Profile/Edit/ProfileEditWrapper.tsx
@@ -1,0 +1,9 @@
+import * as S from "./ProfileEdit.style";
+
+export default function ProfileEditWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <S.ProfileEditWrapper>{children}</S.ProfileEditWrapper>;
+}

--- a/src/components/Pages/Signup/SignupButton/SignupButton.tsx
+++ b/src/components/Pages/Signup/SignupButton/SignupButton.tsx
@@ -6,6 +6,7 @@ import SignupJobs from "@/types/enum/signupJobs";
 import { useSignupMutation } from "@/hooks/api/useSignupMutation";
 import { useRouter } from "next/navigation";
 import validateNickname from "@/utils/validateNickname";
+import getJobKey from "@/utils/getJobKey";
 import * as S from "./SignupButton.style";
 
 export default function SignupButton() {
@@ -16,13 +17,6 @@ export default function SignupButton() {
     !nickname || job === SignupJobs.NONE || !validateNickname(nickname);
 
   const { mutate: signupMutate, isPending, isError } = useSignupMutation();
-
-  // job 변환 (ex. "개발자" -> "DEVELOPER")
-  const getJobKey = (jobValue: string) =>
-    (Object.entries(SignupJobs).find(
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      ([_, value]) => value === jobValue
-    )?.[0] as keyof typeof SignupJobs) || "";
 
   const handleSignup = () => {
     signupMutate({

--- a/src/components/Pages/Signup/SignupTitle/SignupTitle.tsx
+++ b/src/components/Pages/Signup/SignupTitle/SignupTitle.tsx
@@ -1,12 +1,11 @@
 import { Logo } from "@/components";
-import { SIGNUP_TEXT } from "@/constants/messages";
 import * as S from "./SignupTitle.style";
 
-export default function SignupTitle() {
+export default function SignupTitle({ titleText }: { titleText: string }) {
   return (
     <S.SignupTitleWrapper>
       <Logo />
-      <S.SignupTitleText>{SIGNUP_TEXT.titleText}</S.SignupTitleText>
+      <S.SignupTitleText>{titleText}</S.SignupTitleText>
     </S.SignupTitleWrapper>
   );
 }

--- a/src/components/Pages/index.ts
+++ b/src/components/Pages/index.ts
@@ -27,3 +27,11 @@ export { default as SignupBodyModuleWrapper } from "./Signup/SignupBodyModuleWra
 // DesignSystem 페이지
 export { default as DesignSystemCardContainer } from "./DesignSystem/DesignCardContainer";
 export { default as DesignSystemCard } from "./DesignSystem/DesignSystemCards";
+
+// profile/edit 페이지
+export { default as ProfileEditWrapper } from "./Profile/Edit/ProfileEditWrapper";
+export { default as ProfileEditModuleWrapper } from "./Profile/Edit/ProfileEditModuleWrapper";
+export { default as ProfileEditBodyModuleWrapper } from "./Profile/Edit/ProfileEditBodyModuleWrapper";
+export { default as ProfileEditButton } from "./Profile/Edit/ProfileEditButton/ProfileEditButton";
+export { default as ProfileEditJob } from "./Profile/Edit/ProfileEditJob/ProfileEditJob";
+export { default as ProfileEditProfile } from "./Profile/Edit/ProfileEditProfile/ProfileEditProfile";

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -7,6 +7,7 @@ const END_POINT = {
   nicknameValidation: "/members/validations/nickname",
   emailVerification: "/members/email/verification",
   modifyEmail: "/members/email",
+  modifyProfile: "/members",
   authorizationUrl: (providerType: string) =>
     `/oauth/${providerType}/authorization-url`,
   socialLogin: (providerType: string) => `/oauth/${providerType}/login`,

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -104,6 +104,17 @@ export const SIGNUP_TEXT = {
   submitButtonText: "회원가입 완료",
 };
 
+export const PROFILE_EDIT_TEXT = {
+  titleText: "프로필 편집",
+  profileText: "사용하실 프로필을 설정해 주세요.",
+  job: {
+    titleText: "직군을 선택해 주세요.",
+    bodyText: "여러 직군을 겸하고 계신다면, 가장 가까운 직군을 골라주세요.",
+  },
+  cancelButtonText: "취소하기",
+  submitButtonText: "프로필 편집 완료",
+};
+
 export const STAR_ICON = "*";
 
 export const ANNOUNCE_PAGE_TEXT = {

--- a/src/hooks/api/profileEdit/useProfileEditMutation.ts
+++ b/src/hooks/api/profileEdit/useProfileEditMutation.ts
@@ -1,0 +1,26 @@
+import { putProfileEdit } from "@/api/userInfo";
+import { IProfileEdit } from "@/types/api/user";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+// eslint-disable-next-line import/prefer-default-export
+export const useProfileEditMutation = (accessToken: string) => {
+  const router = useRouter();
+  return useMutation({
+    mutationFn: async ({
+      nickname,
+      profileImageObjectKey,
+      job,
+    }: IProfileEdit) => {
+      const response = await putProfileEdit(accessToken, {
+        nickname,
+        profileImageObjectKey,
+        job,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      router.push("/profile");
+    },
+  });
+};

--- a/src/hooks/store/useProfileEditStore.ts
+++ b/src/hooks/store/useProfileEditStore.ts
@@ -1,4 +1,4 @@
-import { IProfileEdit } from "@/types/api/user";
+import { IMemberSummary, IProfileEdit } from "@/types/api/user";
 import SignupJobs from "@/types/enum/signupJobs";
 import getJobKey from "@/utils/getJobKey";
 import { create } from "zustand";
@@ -10,6 +10,7 @@ interface IProfileEditState {
 interface IProfileEditActions {
   setProfileInfo: (profileInfo: IProfileEdit) => void;
   cancelEdit: () => void;
+  initializeWithUserInfo: (userInfo: IMemberSummary) => void;
 }
 
 const defaultState: IProfileEdit = {
@@ -25,4 +26,13 @@ export const useProfileEditStore = create<
   profileInfo: defaultState,
   setProfileInfo: (profileInfo: IProfileEdit) => set({ profileInfo }),
   cancelEdit: () => set({ profileInfo: defaultState }),
+  initializeWithUserInfo: (userInfo) =>
+    set({
+      profileInfo: {
+        nickname: userInfo.nickname,
+        // TODO: 이미지 구현되면 수정 필요
+        profileImageObjectKey: userInfo.profileImageUrl,
+        job: userInfo.job,
+      },
+    }),
 }));

--- a/src/hooks/store/useProfileEditStore.ts
+++ b/src/hooks/store/useProfileEditStore.ts
@@ -1,0 +1,28 @@
+import { IProfileEdit } from "@/types/api/user";
+import SignupJobs from "@/types/enum/signupJobs";
+import getJobKey from "@/utils/getJobKey";
+import { create } from "zustand";
+
+interface IProfileEditState {
+  profileInfo: IProfileEdit;
+}
+
+interface IProfileEditActions {
+  setProfileInfo: (profileInfo: IProfileEdit) => void;
+  cancelEdit: () => void;
+}
+
+const defaultState: IProfileEdit = {
+  nickname: "",
+  profileImageObjectKey: "",
+  job: getJobKey(SignupJobs.NONE),
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const useProfileEditStore = create<
+  IProfileEditState & IProfileEditActions
+>((set) => ({
+  profileInfo: defaultState,
+  setProfileInfo: (profileInfo: IProfileEdit) => set({ profileInfo }),
+  cancelEdit: () => set({ profileInfo: defaultState }),
+}));

--- a/src/hooks/store/useTokenStore.ts
+++ b/src/hooks/store/useTokenStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 interface ITokenState {
   accessToken: string | undefined;
@@ -12,10 +13,21 @@ interface ITokenActions {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export const useTokenStore = create<ITokenState & ITokenActions>((set) => ({
-  accessToken: undefined,
-  memberId: 0,
-  setAccessToken: (accessToken: string) => set({ accessToken }),
-  setMemberId: (memberId: number) => set({ memberId }),
-  logout: () => set({ accessToken: "" }),
-}));
+export const useTokenStore = create<ITokenState & ITokenActions>()(
+  persist(
+    (set) => ({
+      accessToken: undefined,
+      memberId: 0,
+      setAccessToken: (accessToken: string) => set({ accessToken }),
+      setMemberId: (memberId: number) => set({ memberId }),
+      logout: () => {
+        set({ accessToken: "", memberId: 0 });
+        localStorage.removeItem("token-storage");
+      },
+    }),
+    {
+      name: "token-storage",
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);

--- a/src/hooks/store/useUserInfoStore.ts
+++ b/src/hooks/store/useUserInfoStore.ts
@@ -1,4 +1,6 @@
 import { IMemberSummary } from "@/types/api/user";
+import SignupJobs from "@/types/enum/signupJobs";
+import getJobKey from "@/utils/getJobKey";
 import { create } from "zustand";
 
 interface IUserInfoState {
@@ -14,6 +16,7 @@ const defaultState: IMemberSummary = {
   isEmailRegistered: false,
   nickname: "",
   profileImageUrl: "",
+  job: getJobKey(SignupJobs.NONE),
 };
 
 // eslint-disable-next-line import/prefer-default-export
@@ -22,5 +25,5 @@ export const useUserInfoStore = create<IUserInfoState & IUserInfoActions>(
     userInfo: defaultState,
     setUserInfo: (userInfo: IMemberSummary) => set({ userInfo }),
     logout: () => set({ userInfo: defaultState }),
-  })
+  }),
 );

--- a/src/stories/Banner/Banner.profile.stories.tsx
+++ b/src/stories/Banner/Banner.profile.stories.tsx
@@ -10,12 +10,6 @@ const meta = {
     $src: {
       control: { type: "text" },
     },
-    userName: {
-      control: { type: "text" },
-    },
-    userJob: {
-      control: { type: "text" },
-    },
     emailAddress: {
       control: { type: "text" },
     },
@@ -31,8 +25,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    userName: "사용자 닉네임",
-    userJob: "직군명",
     emailAddress: "componote@componote.com",
     loginInfo: `Google 소셜 ${BANNER_TEXT.profile.loginInfoText}`,
   },

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -11,3 +11,9 @@ export interface ISignupUser {
   job: keyof typeof SignupJobs;
   socialAccountToken: string;
 }
+
+export interface IProfileEdit {
+  nickname: string;
+  profileImageObjectKey: string;
+  job: keyof typeof SignupJobs;
+}

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -4,6 +4,7 @@ export interface IMemberSummary {
   isEmailRegistered: boolean;
   nickname: string;
   profileImageUrl: string;
+  job: keyof typeof SignupJobs;
 }
 
 export interface ISignupUser {

--- a/src/utils/getJobKey.ts
+++ b/src/utils/getJobKey.ts
@@ -1,0 +1,15 @@
+import SignupJobs from "@/types/enum/signupJobs";
+
+/**
+ * job 변환 (ex. "개발자" -> "DEVELOPER")
+ * @param jobValue
+ * @returns
+ */
+export default function getJobKey(jobValue: SignupJobs) {
+  return (
+    (Object.entries(SignupJobs).find(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ([_, value]) => value === jobValue
+    )?.[0] as keyof typeof SignupJobs) || ""
+  );
+}


### PR DESCRIPTION
## 🚀 작업 내용

- 프로필 편집 기능을 구현했습니다.

## ✨ 작업 상세 설명

- 프로필 편집 페이지 (`profile/edit`) UI 구현
![image](https://github.com/user-attachments/assets/a3e992bc-63e0-43cb-8ee3-9e03a09807b6)

[추가]
- 컴포넌트 페이지 상단바에 로그인 되어있으면 Avatar로 뜨도록 했어요
![image](https://github.com/user-attachments/assets/cd489b82-2703-4321-b0d3-f2f88bb59214)
- 임시로 일단 상단바의 Avatar를 누르면 바로 마이페이지로 가도록 했습니다 (디자인 상으로는 context menu가 떠야 함)

### 🔥 문제 상황 (선택)

페이지 새로고침이나 이동시 `accessToken`이 초기화되는 문제가 있었습니다

### 💦 해결 방법 (선택)

`sessionStorage`에 저장하도록 `useTokenStore()`를 변경했습니다.

```typescript
export const useTokenStore = create<ITokenState & ITokenActions>()(
  persist(
    (set) => ({
      accessToken: undefined,
      memberId: 0,
      setAccessToken: (accessToken: string) => set({ accessToken }),
      setMemberId: (memberId: number) => set({ memberId }),
      logout: () => {
        set({ accessToken: "", memberId: 0 });
        localStorage.removeItem("token-storage");
      },
    }),
    {
      name: "token-storage",
      storage: createJSONStorage(() => sessionStorage),
    }
  )
);
```
## 🔨 추후 수정해야 하는 부분 (선택)

- 상단바의 Avatar를 누르면 context menu가 뜨도록
- 프로필 사진도 연결이 되면 그 부분도 구현해야 함
- 현재 직업이 enum으로만 되어있고, `getJobKey`라는 util로 key값을 얻는데, 이 방법이 그리 좋은 것 같지는 않음..

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
