### PR TITLE
[✨feat]: 디자인 시스템 페이지 필터 기능 구현

### DIFF
--- a/src/api/designSystem.ts
+++ b/src/api/designSystem.ts
@@ -2,15 +2,19 @@ import END_POINT from "@/constants/api";
 import axiosInstance from "./interceptor";
 
 // eslint-disable-next-line import/prefer-default-export
-export const getDesignSystem = async (
-  page: number,
-  size: number,
-  keyword?: string,
-  types?: string,
-  sort?: string
-) => {
-  const { data } = await axiosInstance.get(END_POINT.searchDesignSystem, {
-    params: { page, size, keyword, types, sort },
+export const getDesignSystem = async ({
+  page,
+  size,
+  types,
+  sort,
+}: {
+  page: number;
+  size: number;
+  types?: string;
+  sort?: string;
+}) => {
+  const { data } = await axiosInstance.get(END_POINT.designSystemSummary, {
+    params: { page, size, types, sort },
   });
 
   return data;

--- a/src/api/designSystem.ts
+++ b/src/api/designSystem.ts
@@ -5,16 +5,16 @@ import axiosInstance from "./interceptor";
 export const getDesignSystem = async ({
   page,
   size,
-  types,
+  filters,
   sort,
 }: {
   page: number;
   size: number;
-  types?: string;
+  filters?: string;
   sort?: string;
 }) => {
   const { data } = await axiosInstance.get(END_POINT.designSystemSummary, {
-    params: { page, size, types, sort },
+    params: { page, size, filters, sort },
   });
 
   return data;

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -28,10 +28,12 @@ import { useTokenStore } from "@/store/user/useTokenStore";
 import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
 import useContextMenuStore from "@/store/common/useContextMenuStore";
 import { IDesignSystemData } from "@/types/api/designSystem";
+import useDesignSystemFilterStore from "@/store/designSystem/useDesignSystemFilterStore";
 
 export default function DesignSystem() {
   const { accessToken } = useTokenStore();
   const { selectedLabel } = useContextMenuStore();
+  const { selectedFilters } = useDesignSystemFilterStore();
 
   const lastElementRef = useRef<HTMLDivElement | null>(null);
   const {
@@ -40,7 +42,10 @@ export default function DesignSystem() {
     hasNextPage,
     isLoading,
     isError,
-  } = useDesignSystemInfiniteQuery(DESIGN_SYSTEM_SORT_CONDITION[selectedLabel]);
+  } = useDesignSystemInfiniteQuery({
+    filters: selectedFilters.join(","),
+    sort: DESIGN_SYSTEM_SORT_CONDITION[selectedLabel],
+  });
 
   useObserver({
     target: lastElementRef,

--- a/src/components/Chip/Chip.group.tsx
+++ b/src/components/Chip/Chip.group.tsx
@@ -21,7 +21,7 @@ export default function ChipGroup({
         const icon = typeof content === "string" ? undefined : content.icon;
         return (
           <Chip
-            key={text}
+            key={`chip-${text}-${content.responseName}`}
             text={text}
             $size="md"
             IconComponent={icon}

--- a/src/components/Chip/Chip.group.tsx
+++ b/src/components/Chip/Chip.group.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { Chip } from "@/components";
+import useDesignSystemFilterStore from "@/store/designSystem/useDesignSystemFilterStore";
+import { DesignSystemFilter } from "@/types/enum/designSystemFilters";
 import { DESIGN_SYSTEM_CHIP_GROUP } from "../../constants/chipGroup";
 import { IChipGroup, IChipGroupComponent } from "./Chip.types";
 import ChipGroupContainer from "./Chip.group.style";
@@ -10,18 +12,11 @@ export default function ChipGroup({
   $width,
 }: IChipGroup & IChipGroupComponent) {
   const chipGroup = DESIGN_SYSTEM_CHIP_GROUP[$variant];
-  const [selectedChip, setSelectedChip] = useState<number[]>([]);
-
-  const handleChipClick = (index: number) => {
-    setSelectedChip((prev) => {
-      if (prev.includes(index)) return prev.filter((i) => i !== index);
-      return [...prev, index];
-    });
-  };
+  const { selectedFilters, toggleFilterChip } = useDesignSystemFilterStore();
 
   return (
     <ChipGroupContainer $width={$width}>
-      {chipGroup.contents.map((content, index) => {
+      {chipGroup.contents.map((content) => {
         const text = typeof content === "string" ? content : content.text;
         const icon = typeof content === "string" ? undefined : content.icon;
         return (
@@ -30,8 +25,12 @@ export default function ChipGroup({
             text={text}
             $size="md"
             IconComponent={icon}
-            $isSelected={selectedChip.includes(index)}
-            onClick={() => handleChipClick(index)}
+            $isSelected={selectedFilters.includes(
+              content.responseName as DesignSystemFilter,
+            )}
+            onClick={() =>
+              toggleFilterChip(content.responseName as DesignSystemFilter)
+            }
           />
         );
       })}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -5,6 +5,7 @@ import arrowDown from "@/assets/icons/arrow-down.svg";
 import checkLineIcon from "@/assets/icons/check-line.svg";
 import useChipStore from "@/store/component/useChipStore";
 import useContextMenuStore from "@/store/common/useContextMenuStore";
+import useDesignSystemFilterStore from "@/store/designSystem/useDesignSystemFilterStore";
 import * as S from "./Toolbar.style";
 import { ButtonStyle } from "../Button/Button.types";
 
@@ -22,6 +23,9 @@ export default function Toolbar({
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
   const resetChips = useChipStore((state) => state.resetChips);
+  const resetFilters = useDesignSystemFilterStore(
+    (state) => state.resetFilters,
+  );
   const {
     selectedLabel,
     isContextMenuOpen,
@@ -32,6 +36,12 @@ export default function Toolbar({
   const handleTabSelect = (index: number) => {
     setSelectedTabIndex(index);
     if (onTabSelect) onTabSelect(index);
+  };
+
+  const handleResetClick = () => {
+    // 임시로 resetChips, resetFilters를 동시에 호출함 => 논의 필요
+    resetChips();
+    resetFilters();
   };
 
   const renderToolList = () => {
@@ -65,7 +75,7 @@ export default function Toolbar({
           <S.FilterIcon />
           {renderToolList()}
           <Button
-            onClick={() => resetChips()}
+            onClick={handleResetClick}
             $size="sm"
             $buttonType="iconButton"
             $leftIcon={resetIcon}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -62,6 +62,7 @@ const END_POINT = {
 
   /* design system */
   searchDesignSystem: "design-systems/search",
+  designSystemSummary: "design-systems",
 };
 
 export default END_POINT;

--- a/src/hooks/api/designSystem/useDesignSystemInfiniteQuery.ts
+++ b/src/hooks/api/designSystem/useDesignSystemInfiniteQuery.ts
@@ -12,7 +12,7 @@ export const useDesignSystemInfiniteQuery = (sort: string) => {
     pageParam,
   }: IPageParam): Promise<IDesignSystemPageData> => {
     const page = typeof pageParam === "number" ? pageParam : 0;
-    const data = await getDesignSystem(page, 10, "", "", sort);
+    const data = await getDesignSystem({ page, size: 10, sort });
 
     return data;
   };

--- a/src/hooks/api/designSystem/useDesignSystemInfiniteQuery.ts
+++ b/src/hooks/api/designSystem/useDesignSystemInfiniteQuery.ts
@@ -7,12 +7,18 @@ interface IPageParam {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export const useDesignSystemInfiniteQuery = (sort: string) => {
+export const useDesignSystemInfiniteQuery = ({
+  filters,
+  sort,
+}: {
+  filters: string;
+  sort: string;
+}) => {
   const fetchDesignSystem = async ({
     pageParam,
   }: IPageParam): Promise<IDesignSystemPageData> => {
     const page = typeof pageParam === "number" ? pageParam : 0;
-    const data = await getDesignSystem({ page, size: 10, sort });
+    const data = await getDesignSystem({ page, size: 10, sort, filters });
 
     return data;
   };
@@ -22,7 +28,7 @@ export const useDesignSystemInfiniteQuery = (sort: string) => {
     Error,
     InfiniteData<IDesignSystemPageData>
   >({
-    queryKey: ["designSytem", sort],
+    queryKey: ["designSystem", filters, sort],
     queryFn: fetchDesignSystem,
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>

--- a/src/store/designSystem/useDesignSystemFilterStore.ts
+++ b/src/store/designSystem/useDesignSystemFilterStore.ts
@@ -1,0 +1,32 @@
+import { DesignSystemFilter } from "@/types/enum/designSystemFilters";
+import { create } from "zustand";
+
+interface IDesignSystemFilterState {
+  selectedFilters: DesignSystemFilter[];
+}
+
+interface IDesignSystemFilterAction {
+  toggleFilterChip: (filter: DesignSystemFilter) => void;
+  // TODO: reset 기능 추가
+  // resetChips: () => void;
+}
+
+const useDesignSystemFilterStore = create<
+  IDesignSystemFilterState & IDesignSystemFilterAction
+>((set) => ({
+  selectedFilters: [],
+  toggleFilterChip: (filter: DesignSystemFilter) =>
+    set((state) => {
+      if (state.selectedFilters.includes(filter))
+        return {
+          selectedFilters: state.selectedFilters.filter(
+            (val) => val !== filter,
+          ),
+        };
+
+      return { selectedFilters: [...state.selectedFilters, filter] };
+    }),
+  // resetChips: () => set({ selectedChips: [0] }),
+}));
+
+export default useDesignSystemFilterStore;

--- a/src/store/designSystem/useDesignSystemFilterStore.ts
+++ b/src/store/designSystem/useDesignSystemFilterStore.ts
@@ -7,8 +7,7 @@ interface IDesignSystemFilterState {
 
 interface IDesignSystemFilterAction {
   toggleFilterChip: (filter: DesignSystemFilter) => void;
-  // TODO: reset 기능 추가
-  // resetChips: () => void;
+  resetFilters: () => void;
 }
 
 const useDesignSystemFilterStore = create<
@@ -26,7 +25,7 @@ const useDesignSystemFilterStore = create<
 
       return { selectedFilters: [...state.selectedFilters, filter] };
     }),
-  // resetChips: () => set({ selectedChips: [0] }),
+  resetFilters: () => set({ selectedFilters: [] }),
 }));
 
 export default useDesignSystemFilterStore;

--- a/src/types/enum/designSystemFilters.ts
+++ b/src/types/enum/designSystemFilters.ts
@@ -51,6 +51,13 @@ export enum PlatformFilter {
   ZEROHEIGHT = "ZEROHEIGHT",
 }
 
+// 필터 전부
+export type DesignSystemFilter =
+  | DeviceFilter
+  | TechFilter
+  | ContentFilter
+  | PlatformFilter;
+
 export enum DesignSystemSortCondition {
   NAME_ASC = "이름 순으로 정렬",
   // VIEW_DESC = "조회 순으로 정렬", → 보류


### PR DESCRIPTION
## 🚀 작업 내용

- 디자인 시스템 필터링 기능을 구현했습니다.

## ✨ 작업 상세 설명

![image](https://github.com/user-attachments/assets/4c1d7ddf-9acc-4a85-8f44-21f7a268df23)

### 🔥 문제 상황 (선택)
 
문제는 아니고 논의 할 내용입니다.
지금 reset버튼을 누르면 컴포넌트 필터와 디자인 시스템 필터가 모두 초기화되도록 했습니다.
Toolbar 안에서 컴포넌트페이지와 디자인 시스템 페이지를 구분할 수 있는 방법이 없어서 이렇게 했는데 논의해보고 리팩토링하면 좋을 것 같습니다~!

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
