### PR TITLE
[♻️refactor]: 상단바 isAuthorized prop 제거

### DIFF
--- a/src/app/announce/page.tsx
+++ b/src/app/announce/page.tsx
@@ -29,7 +29,6 @@ export default function Announce() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/app/component/[componentId]/page.tsx
+++ b/src/app/component/[componentId]/page.tsx
@@ -44,7 +44,6 @@ export default function ComponentDetail() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/app/component/page.tsx
+++ b/src/app/component/page.tsx
@@ -29,7 +29,6 @@ import {
 } from "@/constants/componentFilter";
 import { COMPONENT_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 import { IComponentData } from "@/types/api/component";
-import { useTokenStore } from "@/store/user/useTokenStore";
 
 export default function Component() {
   const router = useRouter();
@@ -37,7 +36,6 @@ export default function Component() {
 
   const { selectedChips } = useChipStore();
   const { selectedLabel } = useContextMenuStore();
-  const { accessToken } = useTokenStore();
 
   const selectedChipNames = selectedChips
     .map((chipIndex) => COMPONENT_FILTER_TYPE[chipIndex])
@@ -60,7 +58,6 @@ export default function Component() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized={!!accessToken}
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/app/designsystem/page.tsx
+++ b/src/app/designsystem/page.tsx
@@ -24,14 +24,12 @@ import { DESIGN_SYSTEM_SORT_CONDITION } from "@/constants/designSystemFilterLabe
 import { DESIGN_SYSTEM_CONTEXT_MENU_ITEM_LABELS } from "@/constants/contextMenuLabels";
 
 import { useObserver } from "@/hooks/api/common/useObserver";
-import { useTokenStore } from "@/store/user/useTokenStore";
 import { useDesignSystemInfiniteQuery } from "@/hooks/api/designSystem/useDesignSystemInfiniteQuery";
 import useContextMenuStore from "@/store/common/useContextMenuStore";
 import { IDesignSystemData } from "@/types/api/designSystem";
 import useDesignSystemFilterStore from "@/store/designSystem/useDesignSystemFilterStore";
 
 export default function DesignSystem() {
-  const { accessToken } = useTokenStore();
   const { selectedLabel } = useContextMenuStore();
   const { selectedFilters } = useDesignSystemFilterStore();
 
@@ -57,7 +55,6 @@ export default function DesignSystem() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized={!!accessToken}
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/app/mybookmark/page.tsx
+++ b/src/app/mybookmark/page.tsx
@@ -28,7 +28,6 @@ export default function MyBookMark() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,17 +2,13 @@
 
 import { Footer, NavigationBar, Layout } from "@/components";
 import { MainContent } from "@/components/Pages";
-import { useTokenStore } from "@/store/user/useTokenStore";
 import { Suspense } from "react";
 
 export default function Home() {
-  const { accessToken } = useTokenStore();
-
   return (
     <Layout>
       <NavigationBar
         $isSeparated={false}
-        $isAuthorized={!!accessToken}
         placeholderText="플레이스 홀더"
         // TODO : 유저 이미지 파일 경로가 있으면 주석 해제
         // userProfileSrc={userInfo.profileImageUrl}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,11 +10,9 @@ import {
 } from "@/components";
 import { NAVBAR_ITEM_TEXT } from "@/constants/messages";
 import { ProfileContainer, ProfileTab } from "@/components/Pages";
-import { useTokenStore } from "@/store/user/useTokenStore";
 
 export default function Profile() {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
-  const { accessToken } = useTokenStore();
 
   const getEmptyStateText = () => {
     if (!selectedTabIndex) return `아직 알림이 없어요`;
@@ -24,7 +22,6 @@ export default function Profile() {
   return (
     <Layout>
       <NavigationBar
-        $isAuthorized={!!accessToken}
         $isSeparated
         placeholderText={NAVBAR_ITEM_TEXT.inputPlaceholder}
       />

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -19,6 +19,7 @@ import { useObserver } from "@/hooks/api/common/useObserver";
 import { ISearchComponentData } from "@/types/api/component";
 import { cleanKorean, extractKorean } from "@/utils/extractKorean";
 
+import { useTokenStore } from "@/store/user/useTokenStore";
 import * as S from "./NavigationBar.style";
 import { ButtonStyle } from "../Button/Button.types";
 import { IInputField, INavigation } from "./NavigationBar.types";
@@ -27,7 +28,6 @@ import ContextMenuItem from "../ContextMenu/ContextMenuItem";
 export default function NavigationBar({
   placeholderText,
   $isSeparated,
-  $isAuthorized,
 }: INavigation & IInputField) {
   const router = useRouter();
   const { searchValue, setSearchValue } = useSearchStore();
@@ -36,6 +36,7 @@ export default function NavigationBar({
 
   const { data, fetchNextPage, hasNextPage, isLoading, isError } =
     useSearchComponentInfiniteQuery(searchValue);
+  const { accessToken } = useTokenStore();
 
   useObserver({
     target: lastElementRef,
@@ -57,7 +58,7 @@ export default function NavigationBar({
 
   return (
     <S.NavigationBarContainer
-      $isAuthorized={$isAuthorized}
+      $isAuthorized={!!accessToken}
       $isSeparated={$isSeparated}
     >
       <S.NavigationBarSection>
@@ -108,7 +109,7 @@ export default function NavigationBar({
                         labelText={cleanKorean(component.title)}
                         badgeLabelText="컴포넌트"
                         subLabelText={extractKorean(component.mixedNames).join(
-                          ", "
+                          ", ",
                         )}
                         onClick={() => handleItemClick(component.id)}
                       />
@@ -120,11 +121,11 @@ export default function NavigationBar({
                     key="noCondition"
                     text="컴포넌트 검색 결과가 없어요"
                   />
-                )
+                ),
               )}
             </Combobox>
           )}
-          {$isAuthorized ? (
+          {accessToken ? (
             <S.NavItemBox>
               {/* TODO: 추후 콤보 박스로 변경해야함. 현재 임시로 Profile 페이지로 이동 */}
               <S.AvatarBox onClick={() => router.push("/profile")}>

--- a/src/components/NavigationBar/NavigationBar.types.ts
+++ b/src/components/NavigationBar/NavigationBar.types.ts
@@ -5,7 +5,7 @@ export interface INavItem {
 
 export interface INavigation {
   $isSeparated: boolean;
-  $isAuthorized: boolean;
+  $isAuthorized?: boolean;
 }
 
 export interface IInputField {


### PR DESCRIPTION
## 🚀 작업 내용
- 상단바의 로그인 버튼 / Avatar 표시 여부를 위해 전달하는 `isAuthrized` prop을 제거함
  어차피 전역으로 상태관리 되기 때문에 해당 prop이 불필요해짐
## ✨ 작업 상세 설명

### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
