### PR TITLE
[🐛fix]: 프로필 편집 후 프로필 페이지에 userInfo 바로 업데이트

### DIFF
--- a/src/hooks/api/profileEdit/useProfileEditMutation.ts
+++ b/src/hooks/api/profileEdit/useProfileEditMutation.ts
@@ -1,11 +1,18 @@
 import { putProfileEdit } from "@/api/userInfo";
+import { useUserInfoStore } from "@/store/user/useUserInfoStore";
 import { IProfileEdit } from "@/types/api/user";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import { useTokenStore } from "@/store/user/useTokenStore";
+import { useUserInfoQuery } from "../useUserInfoQuery";
 
 // eslint-disable-next-line import/prefer-default-export
 export const useProfileEditMutation = (accessToken: string) => {
+  const { setUserInfo } = useUserInfoStore();
+  const { memberId } = useTokenStore();
+  const { refetch } = useUserInfoQuery(accessToken, memberId);
   const router = useRouter();
+
   return useMutation({
     mutationFn: async ({
       nickname,
@@ -19,7 +26,11 @@ export const useProfileEditMutation = (accessToken: string) => {
       });
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      const { data: newUserInfo } = await refetch();
+      if (newUserInfo) {
+        setUserInfo(newUserInfo);
+      }
       router.push("/profile");
     },
   });


### PR DESCRIPTION
## 🚀 작업 내용

- 프로필 편집 후 프로필 페이지로 돌아왔을 때 회원 정보가 업데이트 되지 않는 오류 수정

## ✨ 작업 상세 설명
- refectch 사용하여 해결했습니다.
### 🔥 문제 상황 (선택)

### 💦 해결 방법 (선택)

## 🔨 추후 수정해야 하는 부분 (선택)

## 📄 REFERENCE (선택)

## 📢 리뷰 요구 사항 (선택)
